### PR TITLE
PTN Ninja Game Header/Clocks, More Chat Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This will start a local dev server for you
 
 If you make any changes just reload the page as caching is turned off
 
-To play locally against the live PlayTak server in the /src/js/server.js on line 208 uncomment that line and reload
+To play locally against the live PlayTak server uncomment line 273 in /src/js/server.js and reload
 
 
 ## TODO

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -930,7 +930,9 @@ a.active svg {
 .margin-bottom--8{
 	margin-bottom: 8px;
 }
-
+.margin-bottom--16{
+	margin-bottom: 16px;
+}
 .margin-bottom--32 {
 	margin-bottom: 32px;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -291,20 +291,14 @@
 						class="rulebox"
 						data-toggle="tooltip" data-placement="auto" title="Stone count - The number of stones/capstones that each player has in this game"
 					></span>
-					<div id="time-increment" style="display: none;">
-						|
-						<span
-							id="time-increment-rule"
-							class="rulebox"
-							data-toggle="tooltip" data-placement="auto" title="Time increment - Extra time added each move"
+					<span id="time-increment" style="display: none;">|</span>
+					<span id="time-increment-rule" class="rulebox"
+						  data-toggle="tooltip" data-placement="auto" title="Time increment - Extra time added each move"
 						></span>
-					</div>
-					<div id="extra-time" style="display: none;">
-						|
-						<span id="extra-time-rule" class="rulebox"
-						data-toggle="tooltip" data-placement="auto" title="Extra Time - The trigger move the player must reach and the amount of extra time to add"
+					<span id="extra-time" style="display: none;">|</span>
+					<span id="extra-time-rule" class="rulebox"
+						  data-toggle="tooltip" data-placement="auto" title="Extra Time - The trigger move the player must reach and the amount of extra time to add"
 						></span>
-					</div>
 				</div>
 
 				<div class="optlist center">

--- a/src/index.html
+++ b/src/index.html
@@ -291,6 +291,14 @@
 						class="rulebox"
 						data-toggle="tooltip" data-placement="auto" title="Stone count - The number of stones/capstones that each player has in this game"
 					></span>
+					<div id="time-increment" style="display: none;">
+						|
+						<span
+							id="time-increment-rule"
+							class="rulebox"
+							data-toggle="tooltip" data-placement="auto" title="Time increment - Extra time added each move"
+						></span>
+					</div>
 					<div id="extra-time" style="display: none;">
 						|
 						<span id="extra-time-rule" class="rulebox"

--- a/src/index.html
+++ b/src/index.html
@@ -292,11 +292,11 @@
 						data-toggle="tooltip" data-placement="auto" title="Stone count - The number of stones/capstones that each player has in this game"
 					></span>
 					<span id="time-increment" style="display: none;">|</span>
-					<span id="time-increment-rule" class="rulebox"
+					<span id="time-increment-rule" class="rulebox" style="display: none;"
 						  data-toggle="tooltip" data-placement="auto" title="Time increment - Extra time added each move"
 						></span>
 					<span id="extra-time" style="display: none;">|</span>
-					<span id="extra-time-rule" class="rulebox"
+					<span id="extra-time-rule" class="rulebox" style="display: none;"
 						  data-toggle="tooltip" data-placement="auto" title="Extra Time - The trigger move the player must reach and the amount of extra time to add"
 						></span>
 				</div>

--- a/src/index.html
+++ b/src/index.html
@@ -570,6 +570,12 @@
 											Show last move highlighter
 										</label>
 									</div>
+									<div>
+										<label>
+											<input type="checkbox" name="2d-header" id="2d-header-toggle" onchange="toggle2DHeader(); event.preventDefault();" checked>
+											Show game header
+										</label>
+									</div>
 								</div>
 							</div>
 						</div>

--- a/src/index.html
+++ b/src/index.html
@@ -1093,6 +1093,8 @@
 														<option value="90">90</option>
 														<option value="120">120</option>
 														<option value="180">180</option>
+														<option value="1*n">n</option>
+														<option value="2*n">2n</option>
 													</select>
 												</div>
 											</div>
@@ -1109,15 +1111,6 @@
 												<div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
 													<div class="card-body">
 														<div class="row">
-															<div class="col-sm-12 margin-bottom--16">
-																<div class="form-check">
-																	<input class="form-check-input" type="checkbox" id="incrementScales">
-																	<label class="form-check-label" for="incrementScales"
-																		data-toggle="tooltip" data-placement="auto"
-																		title="When enabled, the increment is multiplied by the move number: on move n, each player receives increment × n seconds."
-																	>Scale increment by move number</label>
-																</div>
-															</div>
 															<div class="col-sm-6">
 																<!-- extra time trigger move -->
 																<div class="form-group">

--- a/src/index.html
+++ b/src/index.html
@@ -328,6 +328,18 @@
 					</button>
 					<button
 						class="navitem"
+						onclick="server.giveTime()"
+						data-toggle="tooltip" data-placement="auto" title="Give 15 seconds to your opponent"
+					>
+						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+							<path
+								d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z"
+							></path>
+							<text x="280" y="430" font-size="180" font-weight="bold" fill="currentColor">+</text>
+						</svg>
+					</button>
+					<button
+						class="navitem"
 						onclick="server.resign()"
 						data-toggle="tooltip" data-placement="auto" title="Resign - You lose the game immediately"
 					>
@@ -1091,6 +1103,15 @@
 												<div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
 													<div class="card-body">
 														<div class="row">
+															<div class="col-sm-12 margin-bottom--16">
+																<div class="form-check">
+																	<input class="form-check-input" type="checkbox" id="incrementScales">
+																	<label class="form-check-label" for="incrementScales"
+																		data-toggle="tooltip" data-placement="auto"
+																		title="When enabled, the increment is multiplied by the move number: on move n, each player receives increment × n seconds."
+																	>Scale increment by move number</label>
+																</div>
+															</div>
 															<div class="col-sm-6">
 																<!-- extra time trigger move -->
 																<div class="form-group">

--- a/src/js/2d-board.js
+++ b/src/js/2d-board.js
@@ -150,6 +150,25 @@ function setDisable2DBoard(value){
 	});
 }
 
+function set2DGameTime(payload){
+	// payload: { time1, time2, timerTurn, lastTimeUpdateWall? }
+	// `lastTimeUpdateWall` (Date.now()) lets PTN Ninja compensate for
+	// postMessage transit delay and stay in sync with this frame's clock.
+	const augmented = {
+		lastTimeUpdateWall: Date.now(),
+		...payload
+	};
+	send2DAction('SET_GAME_TIME', augmented);
+}
+
+function set2DGameTimerTurn(turn){
+	send2DAction('SET_GAME_TIMER_TURN', turn);
+}
+
+function set2DTimerLive(value){
+	send2DAction('SET_TIMER_LIVE', Boolean(value));
+}
+
 function set2DBoardPadding(){
 	const notationWidth = document.getElementById("rmenu").clientWidth;
 	const settingsWidth = document.getElementById("settings-drawer").clientWidth;

--- a/src/js/chat.js
+++ b/src/js/chat.js
@@ -161,12 +161,21 @@ var chathandler={
 		$cs.append('<div class="chat-move-marker">' + escapeHtml(label) + '</div>');
 		$("#room_divs").scrollTop($("#room_divs")[0].scrollHeight);
 	},
-	insertGameSeparator: function(roomId){
+	lastSeparatorGameId: {},
+	insertGameSeparator: function(roomId, gameId){
 		if(!roomId || !this.rooms.hasOwnProperty(roomId)){return;}
+		// Only insert a separator once per distinct game for a given room.
+		// Re-observing the same game (e.g. switching away and back) reuses the
+		// existing chat room and should not introduce another separator.
+		if(gameId && this.lastSeparatorGameId[roomId] === gameId){return;}
 		const $cs = this.rooms[roomId][1];
-		if($cs.children().length === 0){return;}
+		if($cs.children().length === 0){
+			if(gameId){this.lastSeparatorGameId[roomId] = gameId;}
+			return;
+		}
 		$cs.append('<hr class="chat-game-separator">');
 		$("#room_divs").scrollTop($("#room_divs")[0].scrollHeight);
+		if(gameId){this.lastSeparatorGameId[roomId] = gameId;}
 	},
 	send: function(){
 		const msg = $('#chat-me').val();

--- a/src/js/chat.js
+++ b/src/js/chat.js
@@ -90,15 +90,15 @@ var chathandler={
 			const isGameRoom = gameData.chatRoom && id === gameData.chatRoom;
 			const moveChanged = isGameRoom && gameData.lastMoveLabel !== gameData.lastShownMoveLabel && gameData.lastMoveLabel;
 
+			if(moveChanged){
+				gameData.lastShownMoveLabel = gameData.lastMoveLabel;
+				$cs.append('<div class="chat-move-marker">' + escapeHtml(gameData.lastMoveLabel) + '</div>');
+			}
+
 			if(timeChanged){
 				let hiddenAttr = localStorage.getItem('hide-chat-time') === 'true' ? ' hidden' : '';
 				$cs.append('<div class="chattime"' + hiddenAttr + '>' + timenow + '</div>');
 				this.rooms[id][2] = timenow;
-			}
-
-			if(moveChanged){
-				gameData.lastShownMoveLabel = gameData.lastMoveLabel;
-				$cs.append('<div class="chat-move-marker">' + escapeHtml(gameData.lastMoveLabel) + '</div>');
 			}
 
 			$cs.append('<span class="chatname context-player">' + name + ':</span>');

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -16,7 +16,7 @@ let gameData = {
 	unrated: false,
 	tournament: false,
 	triggerMove: 0,
-	timeAmount: 0,
+	extraTimeAmount: 0,
 	bot: 0,
 	is_scratch: true,
 	observing: false,
@@ -64,7 +64,7 @@ function resetGameDataToDefault(){
 		unrated: false,
 		tournament: false,
 		triggerMove: 0,
-		timeAmount: 0,
+		extraTimeAmount: 0,
 		bot: 0,
 		is_scratch: true,
 		observing: false,
@@ -122,12 +122,14 @@ function initBoard(){
 
 	if(gameData.increment > 0){
 		document.getElementById("time-increment").style.display = 'block';
+		document.getElementById("time-increment-rule").style.display = 'block';
 		document.getElementById("time-increment-rule").innerHTML = `+${gameData.increment}`;
 	}
 
-	if(gameData.triggerMove > 0){
+	if(gameData.triggerMove > 0 && gameData.extraTimeAmount > 0){
 		document.getElementById("extra-time").style.display = 'block';
-		document.getElementById("extra-time-rule").innerHTML = `${gameData.triggerMove}/+${gameData.timeAmount/60}`;
+		document.getElementById("extra-time-rule").style.display = 'block';
+		document.getElementById("extra-time-rule").innerHTML = `${gameData.triggerMove}/+${gameData.extraTimeAmount/60}`;
 	}
 	// reset the game data and set new values
 	if(!is2DBoard){
@@ -390,8 +392,11 @@ function clearNotationMenu(){
 	const tbl = document.getElementById("moveslist");
 	while(tbl.rows.length > 0){tbl.deleteRow(0);}
 	document.getElementById("time-increment-rule").innerHTML = '';
+	document.getElementById("time-increment-rule").style.display = "none";
 	document.getElementById("time-increment").style.display = "none";
+
 	document.getElementById("extra-time-rule").innerHTML = '';
+	document.getElementById("extra-time-rule").style.display = "none";
 	document.getElementById("extra-time").style.display = "none";
 	$('#draw').removeClass('i-offered-draw').removeClass('opp-offered-draw').addClass('offer-draw');
 	stopTime();

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -16,7 +16,7 @@ let gameData = {
 	unrated: false,
 	tournament: false,
 	triggerMove: 0,
-	extraTimeAmount: 0,
+	timeAmount: 0,
 	bot: 0,
 	is_scratch: true,
 	observing: false,
@@ -64,7 +64,7 @@ function resetGameDataToDefault(){
 		unrated: false,
 		tournament: false,
 		triggerMove: 0,
-		extraTimeAmount: 0,
+		timeAmount: 0,
 		bot: 0,
 		is_scratch: true,
 		observing: false,
@@ -126,10 +126,10 @@ function initBoard(){
 		document.getElementById("time-increment-rule").innerHTML = `+${gameData.increment}`;
 	}
 
-	if(gameData.triggerMove > 0 && gameData.extraTimeAmount > 0){
+	if(gameData.triggerMove > 0 && gameData.timeAmount > 0){
 		document.getElementById("extra-time").style.display = 'block';
 		document.getElementById("extra-time-rule").style.display = 'block';
-		document.getElementById("extra-time-rule").innerHTML = `${gameData.triggerMove}/+${gameData.extraTimeAmount/60}`;
+		document.getElementById("extra-time-rule").innerHTML = `${gameData.triggerMove}/+${gameData.timeAmount/60}`;
 	}
 	// reset the game data and set new values
 	if(!is2DBoard){

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -119,11 +119,17 @@ function initBoard(){
 	$("#piecerule").html(gameData.pieces + "/" + gameData.capstones);
 	document.getElementById("player-opp").className = "selectplayer";
 	document.getElementById("player-me").className = "";
+
+	if(gameData.increment > 0){
+		document.getElementById("time-increment").style.display = 'block';
+		document.getElementById("time-increment-rule").innerHTML = `+${gameData.increment}`;
+	}
+
 	if(gameData.triggerMove > 0){
 		document.getElementById("extra-time").style.display = 'block';
 		document.getElementById("extra-time-rule").innerHTML = `${gameData.triggerMove}/+${gameData.timeAmount/60}`;
 	}
-	// reset the game data and new new values
+	// reset the game data and set new values
 	if(!is2DBoard){
 		board.clear();
 		board.create(gameData.size, gameData.pieces, gameData.capstones);

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -389,6 +389,8 @@ function formatTime(time){
 function clearNotationMenu(){
 	const tbl = document.getElementById("moveslist");
 	while(tbl.rows.length > 0){tbl.deleteRow(0);}
+	document.getElementById("time-increment-rule").innerHTML = '';
+	document.getElementById("time-increment").style.display = "none";
 	document.getElementById("extra-time-rule").innerHTML = '';
 	document.getElementById("extra-time").style.display = "none";
 	$('#draw').removeClass('i-offered-draw').removeClass('opp-offered-draw').addClass('offer-draw');

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -176,6 +176,13 @@ function incrementMoveCounter(){
 	}
 
 	$('#undo').removeClass('i-requested-undo').removeClass('opp-requested-undo').addClass('request-undo');
+
+	// Flip the active clock in the PTN Ninja iframe so its countdown follows the
+	// new turn between server Time updates. Skip during history replay.
+	if(is2DBoard && !loadingGameHistory){
+		const timerTurn = (gameData.move_count % 2 === 0) ? 1 : 2;
+		set2DGameTimerTurn(timerTurn);
+	}
 }
 
 function load(){
@@ -289,6 +296,26 @@ function loadCurrentGameState(){
 		$(".player1-name:first").html(parsed.tags.Player1 || 'You');
 		$(".player2-name:first").html(parsed.tags.Player2 || 'You');
 	}
+
+	// clearNotationMenu() zeroed the clocks; restore them from the latest
+	// server-authoritative values so the built-in clocks don't display 00:00
+	// until the next Time message arrives.
+	if(lastTimeUpdate){
+		if(gameData.is_game_end){
+			settimers(lastWt, lastBt);
+		}
+		else{
+			startTime(true);
+		}
+		// Also forward the current clock state to the PTN Ninja iframe. This
+		// covers toggling the 2D board on mid-game (e.g. after refreshing the
+		// page with the 2D board disabled): the iframe was not receiving Time
+		// updates while hidden, so its clocks would otherwise stay unset until
+		// the next move.
+		if(is2DBoard){
+			forward2DGameTime(lastWt, lastBt);
+		}
+	}
 }
 
 function processPendingServerMoves(){
@@ -345,6 +372,38 @@ function stopTime(){
 	server.timervar = null;
 }
 
+// Forward authoritative clock values from the PlayTak server to the PTN Ninja
+// iframe (when the 2D board is active). Enables live countdown on first call.
+// The caller passes the raw remaining-time values from the last authoritative
+// server Time update (lastWt/lastBt). Since the iframe stamps its reference
+// point to "now" (Date.now()) when the message arrives, we subtract the time
+// elapsed since lastTimeUpdate from the active side so the forwarded values
+// correspond to the current moment. Without this, toggling the board on
+// after a delay would freeze the iframe clock at the stale snapshot value.
+function forward2DGameTime(p1t, p2t){
+	if(!is2DBoard){return;}
+	const timerTurn = (gameData.move_count % 2 === 0) ? 1 : 2;
+	let time1 = p1t;
+	let time2 = p2t;
+	if(lastTimeUpdate && !gameData.is_game_end){
+		const elapsed = Math.max(invarianttime() - lastTimeUpdate, 0);
+		if(timerTurn === 1){
+			time1 = Math.max(p1t - elapsed, 0);
+		}
+		else{
+			time2 = Math.max(p2t - elapsed, 0);
+		}
+	}
+	set2DGameTime({
+		time1: time1,
+		time2: time2,
+		timerTurn: timerTurn
+	});
+	if(!gameData.is_game_end){
+		set2DTimerLive(true);
+	}
+}
+
 function settimers(p1t,p2t,noHurry){
 	$('.player1-time:first').html(formatTime(p1t));
 	$('.player2-time:first').html(formatTime(p2t));
@@ -387,6 +446,9 @@ function clearNotationMenu(){
 	document.getElementById("extra-time").style.display = "none";
 	$('#draw').removeClass('i-offered-draw').removeClass('opp-offered-draw').addClass('offer-draw');
 	stopTime();
+	if(is2DBoard){
+		set2DTimerLive(false);
+	}
 
 	$('#player-me-name').removeClass('player1-name');
 	$('#player-me-name').removeClass('player2-name');
@@ -683,6 +745,13 @@ function undoMove(){
 	$('.curmove:first').removeClass('curmove');
 	$('.moveno'+(gameData.move_shown-1)+':first').addClass('curmove');
 	storeNotation();
+
+	// Flip the active clock in the PTN Ninja iframe back to the undone player's
+	// side. The subsequent server Time message will correct clock values.
+	if(is2DBoard){
+		const timerTurn = (gameData.move_count % 2 === 0) ? 1 : 2;
+		set2DGameTimerTurn(timerTurn);
+	}
 }
 
 function checkIfMyMove(){

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -10,6 +10,7 @@ let gameData = {
 	size: 5,
 	time: null,
 	increment: null,
+	incrementScales: false,
 	komi: 0,
 	pieces: 21,
 	capstones: 1,
@@ -58,6 +59,7 @@ function resetGameDataToDefault(){
 		size: 5,
 		time: null,
 		increment: null,
+		incrementScales: false,
 		komi: 0,
 		pieces: 21,
 		capstones: 1,
@@ -122,8 +124,12 @@ function initBoard(){
 
 	if(gameData.increment > 0){
 		document.getElementById("time-increment").style.display = 'block';
-		document.getElementById("time-increment-rule").style.display = 'block';
-		document.getElementById("time-increment-rule").innerHTML = `+${gameData.increment}`;
+		const incrementRule = document.getElementById("time-increment-rule");
+		incrementRule.style.display = 'block';
+		incrementRule.innerHTML = `+${minuteseconds(gameData.increment)}${gameData.incrementScales ? '&times;n' : ''}`;
+		incrementRule.setAttribute('title', gameData.incrementScales
+			? `Time increment - +${gameData.increment} seconds added each move, scaled by move number`
+			: 'Time increment - Extra time added each move');
 	}
 
 	if(gameData.triggerMove > 0 && gameData.timeAmount > 0){

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -124,12 +124,22 @@ function initBoard(){
 
 	if(gameData.increment > 0){
 		document.getElementById("time-increment").style.display = 'block';
-		const incrementRule = document.getElementById("time-increment-rule");
-		incrementRule.style.display = 'block';
-		incrementRule.innerHTML = `+${minuteseconds(gameData.increment)}${gameData.incrementScales ? '&times;n' : ''}`;
-		incrementRule.setAttribute('title', gameData.incrementScales
+		const $incrementRule = $("#time-increment-rule");
+		$incrementRule.css('display', 'block');
+		$incrementRule.html(`+${minuteseconds(gameData.increment)}${gameData.incrementScales ? '&times;n' : ''}`);
+		const tooltipText = gameData.incrementScales
 			? `Time increment - +${gameData.increment} seconds added each move, scaled by move number`
-			: 'Time increment - Extra time added each move');
+			: 'Time increment - Extra time added each move';
+		// If Bootstrap has already initialized a tooltip on this node, it has
+		// moved the original title to `data-original-title` and stripped the
+		// native `title` — so set both attrs to keep things in sync and avoid
+		// a duplicate native browser tooltip showing alongside Bootstrap's.
+		if($incrementRule.data('bs.tooltip')){
+			$incrementRule.attr('data-original-title', tooltipText).removeAttr('title');
+		}
+		else{
+			$incrementRule.attr('title', tooltipText);
+		}
 	}
 
 	if(gameData.triggerMove > 0 && gameData.timeAmount > 0){

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -361,6 +361,16 @@ function adjustBoardWidth(){
 // time controls
 function startTime(fromFn){
 	if(typeof fromFn === 'undefined' && !server.timervar){return;}
+	// The clock only runs once the first move has been played. The server keeps
+	// both clocks fixed at the starting time and never ticks pre-game. Players
+	// don't receive a Time update before the game starts, but spectators get one
+	// on Observe, so without this guard their active clock would count down
+	// locally even though the game hasn't started.
+	if(gameData.move_count === 0){
+		settimers(lastWt, lastBt);
+		stopTime();
+		return;
+	}
 	const t = invarianttime();
 	const elapsed = t - lastTimeUpdate;
 	let t1;
@@ -406,10 +416,12 @@ function stopTime(){
 // after a delay would freeze the iframe clock at the stale snapshot value.
 function forward2DGameTime(p1t, p2t){
 	if(!is2DBoard){return;}
+	// Mirror startTime(): the clock is not live until the first move is played.
+	const gameStarted = gameData.move_count > 0;
 	const timerTurn = (gameData.move_count % 2 === 0) ? 1 : 2;
 	let time1 = p1t;
 	let time2 = p2t;
-	if(lastTimeUpdate && !gameData.is_game_end){
+	if(gameStarted && lastTimeUpdate && !gameData.is_game_end){
 		const elapsed = Math.max(invarianttime() - lastTimeUpdate, 0);
 		if(timerTurn === 1){
 			time1 = Math.max(p1t - elapsed, 0);
@@ -423,9 +435,7 @@ function forward2DGameTime(p1t, p2t){
 		time2: time2,
 		timerTurn: timerTurn
 	});
-	if(!gameData.is_game_end){
-		set2DTimerLive(true);
-	}
+	set2DTimerLive(gameStarted && !gameData.is_game_end);
 }
 
 function settimers(p1t,p2t,noHurry){

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -182,8 +182,15 @@ function init() {
 	clearStoredNotation();
 	loadInterfaceSettings();
 	const ninjaElement = document.getElementById("ninja");
+	// Show game header (turn indicator, player names, clocks) defaults to true,
+	// but honor the user's saved preference when loading the iframe.
+	const showHeader = localStorage.getItem("2d-header") !== "false";
 	const ninjaParams =
-		"&moveNumber=false&unplayedPieces=true&disableStoneCycling=true&showBoardPrefsBtn=false&disableNavigation=true&disablePTN=true&disableText=true&flatCounts=false&turnIndicator=false&showHeader=false&showEval=false&showRoads=false&stackCounts=false&notifyGame=false";
+		"&moveNumber=false&unplayedPieces=true&disableStoneCycling=true&showBoardPrefsBtn=false&disableNavigation=true&disablePTN=true&disableText=true&flatCounts=false&turnIndicator=" +
+		showHeader +
+		"&gameTimer=" +
+		showHeader +
+		"&showHeader=false&showEval=false&showRoads=false&stackCounts=false&notifyGame=false";
 	if (
 		window.location.host.indexOf("localhost") > -1 ||
 		window.location.host.indexOf("127.0.0.1") > -1 ||

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -413,13 +413,13 @@ function copyNotationToClipboard() {
 }
 
 function openInPtnNinja() {
-	const link = "http://ptn.ninja/" + encodeURIComponent(getNotation());
+	const link = "https://ptn.ninja/" + encodeURIComponent(getNotation());
 	window.open(link, "_blank");
 }
 
 function copyNotationLink() {
 	const link =
-		"http://www.playtak.com/?load=" + encodeURIComponent(getNotation());
+		"https://www.playtak.com/?load=" + encodeURIComponent(getNotation());
 
 	navigator.clipboard.writeText(link).then(
 		() => {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,3 +1,11 @@
+// Parses an #incselect value like "20" or "1*n" into { increment, increment_scales }.
+function parseIncrementValue(value) {
+	const str = String(value ?? "0");
+	const scales = str.endsWith("*n");
+	const increment = parseInt(scales ? str.slice(0, -2) : str, 10) || 0;
+	return { increment, increment_scales: scales };
+}
+
 const gamePresets = {
 	beginner: {
 		size: 6,
@@ -6,8 +14,7 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 900,
-		increment: 10,
-		increment_scales: false,
+		increment: "10",
 		trigger_move: "",
 		time_amount: "",
 		required_fields: ["opname"],
@@ -19,8 +26,7 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 900,
-		increment: 10,
-		increment_scales: false,
+		increment: "10",
 		trigger_move: "",
 		time_amount: "",
 		required_fields: ["opname"],
@@ -32,8 +38,7 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 900, // seconds
-		increment: 10,
-		increment_scales: false,
+		increment: "10",
 		trigger_move: 35,
 		time_amount: 300, // seconds
 		required_fields: ["opname"],
@@ -45,8 +50,7 @@ const gamePresets = {
 		pieces: 40,
 		capstones: 2,
 		time: 1200, // seconds
-		increment: 15,
-		increment_scales: false,
+		increment: "15",
 		trigger_move: 40,
 		time_amount: 600, // seconds
 		required_fields: ["opname"],
@@ -58,8 +62,7 @@ const gamePresets = {
 		pieces: 40,
 		capstones: 2,
 		time: 300, // seconds
-		increment: 5,
-		increment_scales: false,
+		increment: "5",
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -71,8 +74,7 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 1200, // seconds
-		increment: 15,
-		increment_scales: false,
+		increment: "15",
 		trigger_move: "35",
 		time_amount: "600", // seconds
 		required_fields: ["opname"],
@@ -84,8 +86,7 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 900, // seconds
-		increment: 15,
-		increment_scales: false,
+		increment: "15",
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -97,8 +98,7 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 600, // seconds
-		increment: 15,
-		increment_scales: false,
+		increment: "15",
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -110,8 +110,7 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 180, // seconds
-		increment: 5,
-		increment_scales: false,
+		increment: "5",
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -502,7 +501,6 @@ function changePreset(event) {
 		document.getElementById("gametype").value = storedValues.type;
 		document.getElementById("timeselect").value = storedValues.time;
 		document.getElementById("incselect").value = storedValues.increment;
-		document.getElementById("incrementScales").checked = !!storedValues.increment_scales;
 		document.getElementById("triggerMove").value = storedValues.trigger_move;
 		document.getElementById("timeAmount").value = storedValues.time_amount;
 		return;
@@ -516,7 +514,6 @@ function changePreset(event) {
 			type: document.getElementById("gametype").value,
 			time: document.getElementById("timeselect").value,
 			increment: document.getElementById("incselect").value,
-			increment_scales: document.getElementById("incrementScales").checked,
 			trigger_move: document.getElementById("triggerMove").value,
 			time_amount: document.getElementById("timeAmount").value,
 		};
@@ -538,8 +535,6 @@ function changePreset(event) {
 		document.getElementById("timeselect").setAttribute("disabled", "true");
 		document.getElementById("incselect").value = preset.increment;
 		document.getElementById("incselect").setAttribute("disabled", "true");
-		document.getElementById("incrementScales").checked = !!preset.increment_scales;
-		document.getElementById("incrementScales").setAttribute("disabled", "true");
 		document.getElementById("triggerMove").value = preset.trigger_move;
 		document.getElementById("triggerMove").setAttribute("disabled", "true");
 		document.getElementById("timeAmount").value = preset.time_amount;
@@ -585,7 +580,6 @@ function resetGameSettings() {
 	document.getElementById("gametype").value = "0";
 	document.getElementById("timeselect").value = "600";
 	document.getElementById("incselect").value = "20";
-	document.getElementById("incrementScales").checked = false;
 	document.getElementById("triggerMove").value = "";
 	document.getElementById("timeAmount").value = "";
 	document.getElementById("colorselect").value = "A";
@@ -607,7 +601,6 @@ function loadGameSettings() {
 	document.getElementById("gametype").value = storedValues.type;
 	document.getElementById("timeselect").value = storedValues.time;
 	document.getElementById("incselect").value = storedValues.increment;
-	document.getElementById("incrementScales").checked = !!storedValues.increment_scales;
 	document.getElementById("triggerMove").value = storedValues.trigger_move;
 	document.getElementById("colorselect").value = storedValues.color || "A";
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -7,6 +7,7 @@ const gamePresets = {
 		capstones: 1,
 		time: 900,
 		increment: 10,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "",
 		required_fields: ["opname"],
@@ -19,6 +20,7 @@ const gamePresets = {
 		capstones: 1,
 		time: 900,
 		increment: 10,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "",
 		required_fields: ["opname"],
@@ -31,6 +33,7 @@ const gamePresets = {
 		capstones: 1,
 		time: 900, // seconds
 		increment: 10,
+		increment_scales: false,
 		trigger_move: 35,
 		time_amount: 300, // seconds
 		required_fields: ["opname"],
@@ -43,6 +46,7 @@ const gamePresets = {
 		capstones: 2,
 		time: 1200, // seconds
 		increment: 15,
+		increment_scales: false,
 		trigger_move: 40,
 		time_amount: 600, // seconds
 		required_fields: ["opname"],
@@ -55,6 +59,7 @@ const gamePresets = {
 		capstones: 2,
 		time: 300, // seconds
 		increment: 5,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -67,6 +72,7 @@ const gamePresets = {
 		capstones: 1,
 		time: 1200, // seconds
 		increment: 15,
+		increment_scales: false,
 		trigger_move: "35",
 		time_amount: "600", // seconds
 		required_fields: ["opname"],
@@ -79,6 +85,7 @@ const gamePresets = {
 		capstones: 1,
 		time: 900, // seconds
 		increment: 15,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -91,6 +98,7 @@ const gamePresets = {
 		capstones: 1,
 		time: 600, // seconds
 		increment: 15,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -103,6 +111,7 @@ const gamePresets = {
 		capstones: 1,
 		time: 180, // seconds
 		increment: 5,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -486,6 +495,7 @@ function changePreset(event) {
 		document.getElementById("gametype").value = storedValues.type;
 		document.getElementById("timeselect").value = storedValues.time;
 		document.getElementById("incselect").value = storedValues.increment;
+		document.getElementById("incrementScales").checked = !!storedValues.increment_scales;
 		document.getElementById("triggerMove").value = storedValues.trigger_move;
 		document.getElementById("timeAmount").value = storedValues.time_amount;
 		return;
@@ -499,6 +509,7 @@ function changePreset(event) {
 			type: document.getElementById("gametype").value,
 			time: document.getElementById("timeselect").value,
 			increment: document.getElementById("incselect").value,
+			increment_scales: document.getElementById("incrementScales").checked,
 			trigger_move: document.getElementById("triggerMove").value,
 			time_amount: document.getElementById("timeAmount").value,
 		};
@@ -520,6 +531,8 @@ function changePreset(event) {
 		document.getElementById("timeselect").setAttribute("disabled", "true");
 		document.getElementById("incselect").value = preset.increment;
 		document.getElementById("incselect").setAttribute("disabled", "true");
+		document.getElementById("incrementScales").checked = !!preset.increment_scales;
+		document.getElementById("incrementScales").setAttribute("disabled", "true");
 		document.getElementById("triggerMove").value = preset.trigger_move;
 		document.getElementById("triggerMove").setAttribute("disabled", "true");
 		document.getElementById("timeAmount").value = preset.time_amount;
@@ -565,6 +578,7 @@ function resetGameSettings() {
 	document.getElementById("gametype").value = "0";
 	document.getElementById("timeselect").value = "600";
 	document.getElementById("incselect").value = "20";
+	document.getElementById("incrementScales").checked = false;
 	document.getElementById("triggerMove").value = "";
 	document.getElementById("timeAmount").value = "";
 	document.getElementById("colorselect").value = "A";
@@ -586,6 +600,7 @@ function loadGameSettings() {
 	document.getElementById("gametype").value = storedValues.type;
 	document.getElementById("timeselect").value = storedValues.time;
 	document.getElementById("incselect").value = storedValues.increment;
+	document.getElementById("incrementScales").checked = !!storedValues.increment_scales;
 	document.getElementById("triggerMove").value = storedValues.trigger_move;
 	document.getElementById("colorselect").value = storedValues.color || "A";
 }

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -653,7 +653,7 @@ var server = {
 				unrated: spl[11] == 1,
 				tournament: spl[12] == 1,
 				triggerMove: spl[13],
-				timeAmount: parseInt(spl[14]) / 60
+				extraTimeAmount: parseInt(spl[14]) / 60
 			};
 			this.gameslist.push(game);
 			this.addGameToWatchList(game);

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -515,7 +515,7 @@ var server = {
 			gameData.unrated = +spl[13];
 			gameData.tournament = +spl[14];
 			gameData.triggerMove = +spl[15];
-			gameData.timeAmount = +spl[16];
+			gameData.extraTimeAmount = +spl[16];
 			gameData.bot = +spl[17];
 			gameData.is_scratch = false;
 			gameData.observing = false;
@@ -618,7 +618,7 @@ var server = {
 			gameData.unrated = +spl[10];
 			gameData.tournament = +spl[11];
 			gameData.triggerMove = +spl[12];
-			gameData.timeAmount = +spl[13];
+			gameData.extraTimeAmount = +spl[13];
 			gameData.bot = 1;
 			gameData.observing = true;
 			gameData.is_scratch = false;
@@ -1109,7 +1109,7 @@ var server = {
 		$('<td/>').append('+'+Math.floor(game.komi/2)+"."+(game.komi&1?"5":"0")).addClass("right komi-rule").attr("data-toggle", "tooltip").attr("title","Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined").appendTo(row);
 		$('<td/>').append(game.pieces+"/"+game.capstones).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title","Stone count - The number of stones/capstones that each player has in this game").appendTo(row);
 		$('<td/>').append(gameType).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", gameTypeText).appendTo(row);
-		$("<td/>").append(game.triggerMove + "/+" + parseInt(game.timeAmount)).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", "Trigger move and extra time to add in minutes").appendTo(row);
+		$("<td/>").append(game.triggerMove + "/+" + parseInt(game.extraTimeAmount)).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", "Trigger move and extra time to add in minutes").appendTo(row);
 
 		const dropdownButton = document.createElement("button");
 		dropdownButton.className = "btn btn-transparent dropdown-toggle";
@@ -1167,7 +1167,7 @@ var server = {
 		// extra time
 		const extraTimeItem = document.createElement("span");
 		extraTimeItem.className = "dropdown-item";
-		extraTimeItem.innerHTML = `<strong>Extra Time:</strong> +${game.timeAmount} minutes`;
+		extraTimeItem.innerHTML = `<strong>Extra Time:</strong> +${game.extraTimeAmount} minutes`;
 		dropdownMenu.appendChild(extraTimeItem);
 		// create  dropdown div with dropdown class
 		const dropdownDiv = document.createElement("div");
@@ -1635,7 +1635,7 @@ var server = {
 			}
 			// swap the player color for the new seek
 			const newColor = game.my_color === "black" ? "W" : "B";
-			this.send(`Rematch ${game.id} ${game.size} ${game.time} ${game.increment} ${newColor} ${game.komi} ${game.pieces} ${game.capstones} ${game.unrated} ${game.tournament} ${game.triggerMove} ${game.timeAmount} ${game.opponent}`);
+			this.send(`Rematch ${game.id} ${game.size} ${game.time} ${game.increment} ${newColor} ${game.komi} ${game.pieces} ${game.capstones} ${game.unrated} ${game.tournament} ${game.triggerMove} ${game.extraTimeAmount} ${game.opponent}`);
 			document.getElementById("rematch").setAttribute("disabled", "disabled");
 			document.getElementById('createSeek').setAttribute("disabled", "disabled");
 			document.getElementById("removeSeek").setAttribute("hidden", "true");

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -515,7 +515,7 @@ var server = {
 			gameData.unrated = +spl[13];
 			gameData.tournament = +spl[14];
 			gameData.triggerMove = +spl[15];
-			gameData.extraTimeAmount = +spl[16];
+			gameData.timeAmount = +spl[16];
 			gameData.bot = +spl[17];
 			gameData.is_scratch = false;
 			gameData.observing = false;
@@ -618,7 +618,7 @@ var server = {
 			gameData.unrated = +spl[10];
 			gameData.tournament = +spl[11];
 			gameData.triggerMove = +spl[12];
-			gameData.extraTimeAmount = +spl[13];
+			gameData.timeAmount = +spl[13];
 			gameData.bot = 1;
 			gameData.observing = true;
 			gameData.is_scratch = false;
@@ -653,7 +653,7 @@ var server = {
 				unrated: spl[11] == 1,
 				tournament: spl[12] == 1,
 				triggerMove: spl[13],
-				extraTimeAmount: parseInt(spl[14]) / 60
+				timeAmount: parseInt(spl[14]) / 60
 			};
 			this.gameslist.push(game);
 			this.addGameToWatchList(game);
@@ -1109,7 +1109,7 @@ var server = {
 		$('<td/>').append('+'+Math.floor(game.komi/2)+"."+(game.komi&1?"5":"0")).addClass("right komi-rule").attr("data-toggle", "tooltip").attr("title","Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined").appendTo(row);
 		$('<td/>').append(game.pieces+"/"+game.capstones).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title","Stone count - The number of stones/capstones that each player has in this game").appendTo(row);
 		$('<td/>').append(gameType).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", gameTypeText).appendTo(row);
-		$("<td/>").append(game.triggerMove + "/+" + parseInt(game.extraTimeAmount)).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", "Trigger move and extra time to add in minutes").appendTo(row);
+		$("<td/>").append(game.triggerMove + "/+" + parseInt(game.timeAmount)).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", "Trigger move and extra time to add in minutes").appendTo(row);
 
 		const dropdownButton = document.createElement("button");
 		dropdownButton.className = "btn btn-transparent dropdown-toggle";
@@ -1167,7 +1167,7 @@ var server = {
 		// extra time
 		const extraTimeItem = document.createElement("span");
 		extraTimeItem.className = "dropdown-item";
-		extraTimeItem.innerHTML = `<strong>Extra Time:</strong> +${game.extraTimeAmount} minutes`;
+		extraTimeItem.innerHTML = `<strong>Extra Time:</strong> +${game.timeAmount} minutes`;
 		dropdownMenu.appendChild(extraTimeItem);
 		// create  dropdown div with dropdown class
 		const dropdownDiv = document.createElement("div");
@@ -1635,7 +1635,7 @@ var server = {
 			}
 			// swap the player color for the new seek
 			const newColor = game.my_color === "black" ? "W" : "B";
-			this.send(`Rematch ${game.id} ${game.size} ${game.time} ${game.increment} ${newColor} ${game.komi} ${game.pieces} ${game.capstones} ${game.unrated} ${game.tournament} ${game.triggerMove} ${game.extraTimeAmount} ${game.opponent}`);
+			this.send(`Rematch ${game.id} ${game.size} ${game.time} ${game.increment} ${newColor} ${game.komi} ${game.pieces} ${game.capstones} ${game.unrated} ${game.tournament} ${game.triggerMove} ${game.timeAmount} ${game.opponent}`);
 			document.getElementById("rematch").setAttribute("disabled", "disabled");
 			document.getElementById('createSeek').setAttribute("disabled", "disabled");
 			document.getElementById("removeSeek").setAttribute("hidden", "true");

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -604,7 +604,7 @@ var server = {
 			chathandler.createRoom("priv-" + opponentname, "<b>" + opponentname + "</b>");
 			chathandler.selectRoom("priv-" + opponentname);
 			gameData.chatRoom = "priv-" + opponentname;
-			chathandler.insertGameSeparator(gameData.chatRoom);
+			chathandler.insertGameSeparator(gameData.chatRoom, gameData.id);
 
 			document.getElementById("chime-sound").currentTime = 0;
 			document.getElementById("chime-sound").play();
@@ -638,7 +638,7 @@ var server = {
 			gameData.observing = true;
 			gameData.is_scratch = false;
 			gameData.chatRoom = "room-" + [p1, p2].sort().join("-");
-			chathandler.insertGameSeparator(gameData.chatRoom);
+			chathandler.insertGameSeparator(gameData.chatRoom, gameData.id);
 			storeNotation(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]`);
 			initBoard();
 			loadingGameHistory = true;

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -254,6 +254,17 @@ var server = {
 				);
 			}
 		}
+		// The server sends the Time update immediately BEFORE the move message,
+		// so when that Time arrived move_count was still the pre-move value: the
+		// clock was frozen (pre-game) or stopped, and only the next move's Time
+		// would restart it. Now that the move is applied and move_count is
+		// current, (re)start the clocks so they begin counting the new side's
+		// time right away. Skipped during the initial history burst, which ends
+		// when the first Time message clears loadingGameHistory.
+		if(!loadingGameHistory && lastTimeUpdate && !gameData.is_game_end){
+			startTime(true);
+			forward2DGameTime(lastWt, lastBt);
+		}
 	},
 
 	connect: function(){

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -364,7 +364,7 @@ var server = {
 	},
 	sendClient: function(){
 		server.send("Client TakWeb-22.04.12");
-		server.send("Protocol 2");
+		server.send("Protocol 3");
 	},
 	login: function(){
 		this.anotherlogin=false;
@@ -509,14 +509,15 @@ var server = {
 			gameData.size = +spl[7];
 			gameData.time = +spl[8];
 			gameData.increment = +spl[9];
-			gameData.komi = +spl[10];
-			gameData.pieces = +spl[11];
-			gameData.capstones = +spl[12];
-			gameData.unrated = +spl[13];
-			gameData.tournament = +spl[14];
-			gameData.triggerMove = +spl[15];
-			gameData.timeAmount = +spl[16];
-			gameData.bot = +spl[17];
+			gameData.incrementScales = +(spl[10] || 0) === 1;
+			gameData.komi = +spl[11];
+			gameData.pieces = +spl[12];
+			gameData.capstones = +spl[13];
+			gameData.unrated = +spl[14];
+			gameData.tournament = +spl[15];
+			gameData.triggerMove = +spl[16];
+			gameData.timeAmount = +spl[17];
+			gameData.bot = +spl[18];
 			gameData.is_scratch = false;
 			gameData.observing = false;
 			storeNotation(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]`);
@@ -612,13 +613,14 @@ var server = {
 			gameData.size = +spl[4];
 			gameData.time = +spl[5];
 			gameData.increment = +spl[6];
-			gameData.komi = +spl[7];
-			gameData.pieces = +spl[8];
-			gameData.capstones = +spl[9];
-			gameData.unrated = +spl[10];
-			gameData.tournament = +spl[11];
-			gameData.triggerMove = +spl[12];
-			gameData.timeAmount = +spl[13];
+			gameData.incrementScales = +(spl[7] || 0) === 1;
+			gameData.komi = +spl[8];
+			gameData.pieces = +spl[9];
+			gameData.capstones = +spl[10];
+			gameData.unrated = +spl[11];
+			gameData.tournament = +spl[12];
+			gameData.triggerMove = +spl[13];
+			gameData.timeAmount = +spl[14];
 			gameData.bot = 1;
 			gameData.observing = true;
 			gameData.is_scratch = false;
@@ -644,16 +646,17 @@ var server = {
 				id: +spl[2],
 				time: +spl[6],
 				increment: +spl[7],
+				incrementScales: +(spl[8] || 0) === 1,
 				player1: spl[3],
 				player2: spl[4],
 				size: +spl[5],
-				komi: +spl[8],
-				pieces: +spl[9],
-				capstones: +spl[10],
-				unrated: spl[11] == 1,
-				tournament: spl[12] == 1,
-				triggerMove: spl[13],
-				timeAmount: parseInt(spl[14]) / 60
+				komi: +spl[9],
+				pieces: +spl[10],
+				capstones: +spl[11],
+				unrated: spl[12] == 1,
+				tournament: spl[13] == 1,
+				triggerMove: spl[14],
+				timeAmount: parseInt(spl[15]) / 60
 			};
 			this.gameslist.push(game);
 			this.addGameToWatchList(game);
@@ -738,6 +741,18 @@ var server = {
 				else if(spl[1] === "RemoveDraw"){
 					$("#draw").removeClass("i-offered-draw").removeClass("opp-offered-draw").addClass("offer-draw");
 					alert("info", "Draw offer is taken back by your opponent");
+				}
+				//Game#1 GivenTime <toColor> <ms>
+				else if(spl[1] === "GivenTime"){
+					const toColor = spl[2];
+					const seconds = Math.round((+spl[3] || 0) / 1000);
+					const youReceived = toColor === gameData.my_color;
+					if(youReceived){
+						alert("info", "Your opponent gave you " + seconds + " seconds");
+					}
+					else{
+						alert("info", "You gave your opponent " + seconds + " seconds");
+					}
 				}
 				//Game#1 Over result
 				else if(spl[1] === "Over"){
@@ -961,16 +976,17 @@ var server = {
 				size: spl[4] + "x" + spl[4],
 				time: Number(spl[5]),
 				increment: Number(spl[6]),
-				color: spl[7],
-				komi: +spl[8],
-				pieces: +spl[9],
-				capstones: +spl[10],
-				unrated: spl[11] == 1,
-				tournament: spl[12] == 1,
-				trigger_move: spl[13],
-				time_amount: (parseInt(spl[14]) / 60).toString(),
-				opponent: spl[15],
-				bot: spl[16],
+				increment_scales: +(spl[7] || 0) === 1,
+				color: spl[8],
+				komi: +spl[9],
+				pieces: +spl[10],
+				capstones: +spl[11],
+				unrated: spl[12] == 1,
+				tournament: spl[13] == 1,
+				trigger_move: spl[14],
+				time_amount: (parseInt(spl[15]) / 60).toString(),
+				opponent: spl[16],
+				bot: spl[17],
 				player_rating: playerRating
 			});
 			this.rendeerseekslist();
@@ -1105,7 +1121,7 @@ var server = {
 		$('<td/>').append(players).click(game,function(ev){server.observegame(ev.data);}).appendTo(row);
 		// game details
 		$('<td/>').append("<span class='badge'>"+game.size+"x"+game.size+"</span>").addClass("right").appendTo(row);
-		$('<td/>').append(minuteseconds(game.time) + ' +'+minuteseconds(game.increment)).addClass("right time-rule").attr("data-toggle", "tooltip").attr("title","Time control and increment").appendTo(row);
+		$('<td/>').append(minuteseconds(game.time) + ' +'+minuteseconds(game.increment) + (game.incrementScales ? '&times;n' : '')).addClass("right time-rule").attr("data-toggle", "tooltip").attr("title", game.incrementScales ? "Time control and increment (increment scales with move number)" : "Time control and increment").appendTo(row);
 		$('<td/>').append('+'+Math.floor(game.komi/2)+"."+(game.komi&1?"5":"0")).addClass("right komi-rule").attr("data-toggle", "tooltip").attr("title","Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined").appendTo(row);
 		$('<td/>').append(game.pieces+"/"+game.capstones).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title","Stone count - The number of stones/capstones that each player has in this game").appendTo(row);
 		$('<td/>').append(gameType).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", gameTypeText).appendTo(row);
@@ -1136,7 +1152,7 @@ var server = {
 		const incrementItem = document.createElement("span");
 		incrementItem.className = "dropdown-item time-rule-menu";
 		incrementItem.style.display = "none";
-		incrementItem.innerHTML = `<strong>Increment:</strong> +${minuteseconds(game.increment)}`;
+		incrementItem.innerHTML = `<strong>Increment:</strong> +${minuteseconds(game.increment)}${game.incrementScales ? ' &times; move number' : ''}`;
 		dropdownMenu.appendChild(incrementItem);
 		// komi
 		const komiItem = document.createElement("span");
@@ -1325,7 +1341,7 @@ var server = {
 			$('<td/>').append(ratingdecoration + " " + (seek.player_rating || "")).addClass("right").attr("data-toggle", "tooltip").attr("title",ratingtext).appendTo(row);
 			// game details
 			$('<td/>').append(sizespan).addClass("right").appendTo(row);
-			$('<td/>').append(minuteseconds(seek.time) + ' +'+minuteseconds(seek.increment)).addClass("right time-rule").attr("data-toggle", "tooltip").attr("title","Time control and increment").appendTo(row);
+			$('<td/>').append(minuteseconds(seek.time) + ' +'+minuteseconds(seek.increment) + (seek.increment_scales ? '&times;n' : '')).addClass("right time-rule").attr("data-toggle", "tooltip").attr("title", seek.increment_scales ? "Time control and increment (increment scales with move number)" : "Time control and increment").appendTo(row);
 			$('<td/>').append((Math.floor(seek.komi/2)||(seek.komi&1?"":"0"))+(seek.komi&1?"&frac12;":"")).addClass("right komi-rule").attr("data-toggle", "tooltip").attr("title","Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined").appendTo(row);
 			$('<td/>').append(seek.pieces+"/"+seek.capstones).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title","Stone count - The number of stones/capstones that each player has in this game").appendTo(row);
 			$('<td/>').append(gameType).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title",gameTypeText).appendTo(row);
@@ -1358,7 +1374,7 @@ var server = {
 			incrementItem.className = "dropdown-item time-rule-menu";
 			// set default display none
 			incrementItem.style.display = "none";
-			incrementItem.innerHTML = `<strong>Increment:</strong> +${minuteseconds(seek.increment)}`;
+			incrementItem.innerHTML = `<strong>Increment:</strong> +${minuteseconds(seek.increment)}${seek.increment_scales ? ' &times; move number' : ''}`;
 			dropdownMenu.appendChild(incrementItem);
 			// komi
 			const komiItem = document.createElement("span");
@@ -1516,6 +1532,7 @@ var server = {
 			size: document.getElementById("boardsize").value,
 			time: document.getElementById("timeselect").value,
 			increment: document.getElementById("incselect").value,
+			increment_scales: document.getElementById("incrementScales").checked,
 			color: document.getElementById("colorselect").value,
 			komi: document.getElementById("komiselect").value,
 			pieces: document.getElementById("piececount").value,
@@ -1529,7 +1546,7 @@ var server = {
 		const opponent = document.getElementById("opname").value.replace(/[^A-Za-z0-9_]/g,"");
 		const unrated = (game.type==2?1:0);
 		const tournament = (game.type==1?1:0);
-		const seekCMD =`Seek ${game.size} ${game.time} ${game.increment} ${game.color} ${game.komi} ${game.pieces} ${game.capstones} ${unrated} ${tournament} ${game.trigger_move || 0} ${game.time_amount || 0} ${opponent}`;
+		const seekCMD =`Seek ${game.size} ${game.time} ${game.increment} ${game.increment_scales ? 1 : 0} ${game.color} ${game.komi} ${game.pieces} ${game.capstones} ${unrated} ${tournament} ${game.trigger_move || 0} ${game.time_amount || 0} ${opponent}`;
 		this.send(seekCMD);
 		$('#creategamemodal').modal('hide');
 		server.newSeek = true;
@@ -1586,6 +1603,12 @@ var server = {
 
 		this.send("Game#" + gameData.id + " Resign");
 	},
+	giveTime: function(){
+		if(gameData.is_scratch){return;}
+		else if(gameData.observing){return;}
+
+		this.send("Game#" + gameData.id + " GiveTime");
+	},
 	acceptseek: function(e, skipDebounce){
 		if(!skipDebounce && this.changeseektime+800>Date.now()){
 			return;
@@ -1635,7 +1658,7 @@ var server = {
 			}
 			// swap the player color for the new seek
 			const newColor = game.my_color === "black" ? "W" : "B";
-			this.send(`Rematch ${game.id} ${game.size} ${game.time} ${game.increment} ${newColor} ${game.komi} ${game.pieces} ${game.capstones} ${game.unrated} ${game.tournament} ${game.triggerMove} ${game.timeAmount} ${game.opponent}`);
+			this.send(`Rematch ${game.id} ${game.size} ${game.time} ${game.increment} ${game.incrementScales ? 1 : 0} ${newColor} ${game.komi} ${game.pieces} ${game.capstones} ${game.unrated} ${game.tournament} ${game.triggerMove} ${game.timeAmount} ${game.opponent}`);
 			document.getElementById("rematch").setAttribute("disabled", "disabled");
 			document.getElementById('createSeek').setAttribute("disabled", "disabled");
 			document.getElementById("removeSeek").setAttribute("hidden", "true");

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -306,6 +306,9 @@ var server = {
 				server.rendeerseekslist();
 				server.updateplayerinfo();
 				stopTime();
+				if(is2DBoard){
+					set2DTimerLive(false);
+				}
 				document.getElementById("removeSeek").removeAttribute("disabled");
 				document.getElementById("createSeek").removeAttribute("disabled");
 
@@ -577,6 +580,18 @@ var server = {
 			const time = gameData.time;
 			settimers(time * 1000, time * 1000);
 
+			// Forward player names + initial clock values to the PTN Ninja iframe.
+			// Live ticking is enabled once the first Time message arrives.
+			if(is2DBoard){
+				set2DBoard(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"][Player1 "${p1}"][Player2 "${p2}"]`);
+				set2DTimerLive(false);
+				set2DGameTime({
+					time1: time * 1000,
+					time2: time * 1000,
+					timerTurn: 1
+				});
+			}
+
 			let opponentname;
 			if(spl[6] === "white"){
 				//I am white
@@ -636,6 +651,17 @@ var server = {
 			document.getElementById('rematch').style.display = "none";
 			const time = +spl[5];
 			settimers(time * 1000, time * 1000);
+
+			// Forward player names + initial clock values to the PTN Ninja iframe.
+			if(is2DBoard){
+				set2DBoard(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"][Player1 "${p1}"][Player2 "${p2}"]`);
+				set2DTimerLive(false);
+				set2DGameTime({
+					time1: time * 1000,
+					time2: time * 1000,
+					timerTurn: 1
+				});
+			}
 		}
 		else if(e.startsWith("GameList Add ")){
 			//GameList Add Game#1 player1 vs player2, 4x4, 180, 15, 0 half-moves played, player1 to move
@@ -701,6 +727,7 @@ var server = {
 
 					lastTimeUpdate = invarianttime();
 					startTime(true);
+					forward2DGameTime(wt, bt);
 				}
 				//Game#1 Timems 170000 200000
 				else if(spl[1] === "Timems"){
@@ -712,6 +739,7 @@ var server = {
 
 					lastTimeUpdate = invarianttime();
 					startTime(true);
+					forward2DGameTime(wt, bt);
 				}
 				//Game#1 RequestUndo
 				else if(spl[1] === "RequestUndo"){
@@ -751,6 +779,9 @@ var server = {
 						chathandler.insertMoveMarker(gameData.chatRoom, gameData.result);
 					}
 					stopTime();
+					if(is2DBoard){
+						set2DTimerLive(false);
+					}
 					document.title = "Play Tak";
 					if(!is2DBoard || !gameData.is_game_end){
 						// Wait for animation to complete before showing game-over dialog
@@ -779,15 +810,17 @@ var server = {
 					const msg = "Game abandoned by " + spl[2] + "." + (gameData.observing ? "" : " You win!");
 
 					if(!gameData.is_scratch && gameData.chatRoom){
-						chathandler.insertTimeMarker(gameData.chatRoom);
 						if(gameData.lastMoveLabel !== gameData.lastShownMoveLabel && gameData.lastMoveLabel){
 							chathandler.insertMoveMarker(gameData.chatRoom, gameData.lastMoveLabel);
 							gameData.lastShownMoveLabel = gameData.lastMoveLabel;
 						}
 						chathandler.insertMoveMarker(gameData.chatRoom, gameData.result);
-						chathandler.insertGameSeparator(gameData.chatRoom);
+						chathandler.insertTimeMarker(gameData.chatRoom);
 					}
 					stopTime();
+					if(is2DBoard){
+						set2DTimerLive(false);
+					}
 
 					// Wait for animation to complete before showing game-over dialog
 					animation.whenComplete(function(){

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -1564,7 +1564,6 @@ var server = {
 			size: document.getElementById("boardsize").value,
 			time: document.getElementById("timeselect").value,
 			increment: document.getElementById("incselect").value,
-			increment_scales: document.getElementById("incrementScales").checked,
 			color: document.getElementById("colorselect").value,
 			komi: document.getElementById("komiselect").value,
 			pieces: document.getElementById("piececount").value,
@@ -1578,7 +1577,8 @@ var server = {
 		const opponent = document.getElementById("opname").value.replace(/[^A-Za-z0-9_]/g,"");
 		const unrated = (game.type==2?1:0);
 		const tournament = (game.type==1?1:0);
-		const seekCMD =`Seek ${game.size} ${game.time} ${game.increment} ${game.increment_scales ? 1 : 0} ${game.color} ${game.komi} ${game.pieces} ${game.capstones} ${unrated} ${tournament} ${game.trigger_move || 0} ${game.time_amount || 0} ${opponent}`;
+		const incParsed = parseIncrementValue(game.increment);
+		const seekCMD =`Seek ${game.size} ${game.time} ${incParsed.increment} ${incParsed.increment_scales ? 1 : 0} ${game.color} ${game.komi} ${game.pieces} ${game.capstones} ${unrated} ${tournament} ${game.trigger_move || 0} ${game.time_amount || 0} ${opponent}`;
 		this.send(seekCMD);
 		$('#creategamemodal').modal('hide');
 		server.newSeek = true;

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -367,7 +367,7 @@ var server = {
 	},
 	sendClient: function(){
 		server.send("Client TakWeb-22.04.12");
-		server.send("Protocol 3");
+		server.send("Protocol 4");
 	},
 	login: function(){
 		this.anotherlogin=false;

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -749,7 +749,6 @@ var server = {
 							gameData.lastShownMoveLabel = gameData.lastMoveLabel;
 						}
 						chathandler.insertMoveMarker(gameData.chatRoom, gameData.result);
-						chathandler.insertGameSeparator(gameData.chatRoom);
 					}
 					stopTime();
 					document.title = "Play Tak";

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -650,6 +650,22 @@ function toggle2DHighlightSquare(){
 	});
 }
 
+function toggle2DHeader(){
+	const checked = document.getElementById('2d-header-toggle').checked;
+	localStorage.setItem('2d-header', checked);
+	// Tied together: the "game header" covers both the turn indicator strip
+	// and the player clocks that live inside it (or above the board).
+	set2DUI({
+		turnIndicator: checked,
+		gameTimer: checked
+	});
+}
+
+function show2DHeaderEnabled(){
+	// Default to true when not set in localStorage
+	return localStorage.getItem('2d-header') !== 'false';
+}
+
 function generate2DThemes(themes){
 	const optionsElement = document.getElementById("2d-theme-options");
 	optionsElement.innerHTML = '';
@@ -737,6 +753,14 @@ function load2DSettings(){
 		document.getElementById('2d-highlight-toggle').checked = value;
 		set2DUI({ highlightSquares: value });
 	}
+
+	// Show game header: default to true when not set
+	const showHeader = show2DHeaderEnabled();
+	document.getElementById('2d-header-toggle').checked = showHeader;
+	set2DUI({
+		turnIndicator: showHeader,
+		gameTimer: showHeader
+	});
 }
 
 /*


### PR DESCRIPTION
- Add toggle for game header (player names, turn indicator, clocks)
- Swap order of time/move markers (show time after move since showing before implies move was made at that time, which it likely wasn't)
- Remove extra separator after game end
- Remove extra separators when re-observing game