### PR TITLE
Add Double Black Stack opening option

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -698,17 +698,8 @@ a.navitem, div.navitem{
 	font-size: 18px;
 	line-height: 1;
 }
-.komi-step-btn:not(:disabled):hover{
+.komi-step-btn:hover{
 	background-color: var(--secondary-bg-color);
-}
-.komi-step-btn:disabled{
-	cursor: not-allowed;
-}
-/* When the stepper is disabled (e.g. a preset fixes the komi value),
-   fade the whole control to match a disabled .form-control. */
-.komi-stepper:has(.komi-step-btn:disabled){
-	opacity: .4;
-	cursor: not-allowed;
 }
 .komi-step-value{
 	display: flex;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -668,49 +668,6 @@ a.navitem, div.navitem{
 	border: 1px solid var(--secondary-border-color);
 }
 
-/* Balancing Mechanism: select with an inline komi stepper that matches its height */
-.balancing-row{
-	display: flex;
-	align-items: stretch;
-	gap: 8px;
-}
-.balancing-row .form-control{
-	flex: 1;
-	min-width: 0;
-}
-.komi-stepper{
-	display: flex;
-	align-items: stretch;
-	border: 1px solid var(--secondary-border-color);
-	border-radius: 0.25rem;
-	background-color: var(--primary-bg-color);
-	overflow: hidden;
-}
-.komi-step-btn{
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	border: none;
-	background: transparent;
-	color: var(--primary-font-color);
-	cursor: pointer;
-	padding: 0 12px;
-	font-size: 18px;
-	line-height: 1;
-}
-.komi-step-btn:hover{
-	background-color: var(--secondary-bg-color);
-}
-.komi-step-value{
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	min-width: 32px;
-	color: var(--primary-font-color);
-	font-size: 14px;
-	user-select: none;
-}
-
 input[type=range] {
 	vertical-align: middle;
 	margin: 0px;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -780,12 +780,21 @@ select, .select.dropdown-toggle {
 	border-bottom: 1px solid var(--primary-border-color);
 }
 
+/* Left-align all columns to match the playtak-games table. This overrides the
+   generic .right utility (lower specificity than .linestable td/th). */
 .linestable td{
 	padding: 8px 4px;
+	text-align: left;
 }
 
 .linestable th{
 	padding: 8px 4px;
+	text-align: left;
+}
+
+/* Rules column: allow "Double Black Stack" to wrap rather than forcing a wide column. */
+.rules-col{
+	white-space: normal;
 }
 
 .colourcircle circle{
@@ -1131,12 +1140,12 @@ a.btn.btn-primary {
 	}
 }
 
-/* max width 500 hide komi */
+/* max width 500: collapse the Rules column into the detail menu (like the old Komi column did) */
 @media (max-width: 500px) {
-	.komi-rule {
+	.rules-rule {
 		display: none;
 	}
-	.komi-rule-menu {
+	.rules-rule-menu {
 		display: block !important;
 	}
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1231,3 +1231,37 @@ a.btn.btn-primary {
 .active .stroke-primary {
 	stroke: var(--dark);
 }
+
+/* || Dark popover — match the dark Bootstrap tooltips (e.g. the increment-scaling help) */
+.popover {
+	background-color: #000;
+	border: 1px solid rgba(255, 255, 255, 0.15);
+}
+.popover .popover-header {
+	background-color: #000;
+	color: #fff;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+.popover .popover-body {
+	color: #fff;
+}
+/* arrow: ::after is the fill (match the black body), ::before is the border */
+.bs-popover-auto[x-placement^=top] > .arrow::after,
+.bs-popover-top > .arrow::after { border-top-color: #000; }
+.bs-popover-auto[x-placement^=top] > .arrow::before,
+.bs-popover-top > .arrow::before { border-top-color: rgba(255, 255, 255, 0.15); }
+.bs-popover-auto[x-placement^=bottom] > .arrow::after,
+.bs-popover-bottom > .arrow::after { border-bottom-color: #000; }
+.bs-popover-auto[x-placement^=bottom] > .arrow::before,
+.bs-popover-bottom > .arrow::before { border-bottom-color: rgba(255, 255, 255, 0.15); }
+.bs-popover-auto[x-placement^=left] > .arrow::after,
+.bs-popover-left > .arrow::after { border-left-color: #000; }
+.bs-popover-auto[x-placement^=left] > .arrow::before,
+.bs-popover-left > .arrow::before { border-left-color: rgba(255, 255, 255, 0.15); }
+.bs-popover-auto[x-placement^=right] > .arrow::after,
+.bs-popover-right > .arrow::after { border-right-color: #000; }
+.bs-popover-auto[x-placement^=right] > .arrow::before,
+.bs-popover-right > .arrow::before { border-right-color: rgba(255, 255, 255, 0.15); }
+/* the bottom-placement notch that sits over the header */
+.popover-header::before,
+.bs-popover-bottom .popover-header::before { border-bottom-color: #000; }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -668,6 +668,49 @@ a.navitem, div.navitem{
 	border: 1px solid var(--secondary-border-color);
 }
 
+/* Balancing Mechanism: select with an inline komi stepper that matches its height */
+.balancing-row{
+	display: flex;
+	align-items: stretch;
+	gap: 8px;
+}
+.balancing-row .form-control{
+	flex: 1;
+	min-width: 0;
+}
+.komi-stepper{
+	display: flex;
+	align-items: stretch;
+	border: 1px solid var(--secondary-border-color);
+	border-radius: 0.25rem;
+	background-color: var(--primary-bg-color);
+	overflow: hidden;
+}
+.komi-step-btn{
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border: none;
+	background: transparent;
+	color: var(--primary-font-color);
+	cursor: pointer;
+	padding: 0 12px;
+	font-size: 18px;
+	line-height: 1;
+}
+.komi-step-btn:hover{
+	background-color: var(--secondary-bg-color);
+}
+.komi-step-value{
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 32px;
+	color: var(--primary-font-color);
+	font-size: 14px;
+	user-select: none;
+}
+
 input[type=range] {
 	vertical-align: middle;
 	margin: 0px;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -698,8 +698,17 @@ a.navitem, div.navitem{
 	font-size: 18px;
 	line-height: 1;
 }
-.komi-step-btn:hover{
+.komi-step-btn:not(:disabled):hover{
 	background-color: var(--secondary-bg-color);
+}
+.komi-step-btn:disabled{
+	cursor: not-allowed;
+}
+/* When the stepper is disabled (e.g. a preset fixes the komi value),
+   fade the whole control to match a disabled .form-control. */
+.komi-stepper:has(.komi-step-btn:disabled){
+	opacity: .4;
+	cursor: not-allowed;
 }
 .komi-step-value{
 	display: flex;

--- a/src/index.html
+++ b/src/index.html
@@ -1031,10 +1031,11 @@
 											</div>
 											<div class="col-sm-6">
 												<!-- balancing mechanism -->
-												<div class="form-group">
-													<label for="balancingselect">Balancing Mechanism
-														<button type="button" class="btn btn-link p-0 align-baseline" style="line-height:1;vertical-align:middle;" data-toggle="popover" data-trigger="focus" data-placement="top" data-html="true" data-content="The mechanism for balancing first-player advantage.<br><br><b>Komi:</b> If the game ends without a road, Black gets this amount added to their final flat count.<br><br><b>Double Black Stack:</b> White's initial placement is a stack of two black flats." aria-label="Balancing mechanism help">&#9432;</button>
-													</label>
+												<div
+													class="form-group"
+													data-toggle="tooltip" data-placement="auto" title="The mechanism for balancing first-player advantage. Komi: If the game ends without a road, Black gets this amount added to their final flat count. Double Black Stack: White's initial placement is a stack of two black flats."
+												>
+													<label for="balancingselect">Balancing Mechanism</label>
 													<div class="balancing-row">
 														<select class="form-control" id="balancingselect" onchange="updateBalancingMechanism(false)">
 															<option value="none" selected="selected">None</option>
@@ -1224,10 +1225,8 @@
 
 									</div>
 									<div class="col-sm-6">
-										<div class="form-group">
-											<label for="scratchBalancingSelect">Balancing Mechanism
-												<button type="button" class="btn btn-link p-0 align-baseline" style="line-height:1;vertical-align:middle;" data-toggle="popover" data-trigger="focus" data-placement="top" data-html="true" data-content="The mechanism for balancing first-player advantage.<br><br><b>Komi:</b> If the game ends without a road, Black gets this amount added to their final flat count.<br><br><b>Double Black Stack:</b> White's initial placement is a stack of two black flats." aria-label="Balancing mechanism help">&#9432;</button>
-											</label>
+										<div class="form-group" data-toggle="tooltip" data-placement="auto" title="The mechanism for balancing first-player advantage. Komi: If the game ends without a road, Black gets this amount added to their final flat count. Double Black Stack: White's initial placement is a stack of two black flats.">
+											<label for="scratchBalancingSelect">Balancing Mechanism</label>
 											<div class="balancing-row">
 												<select class="form-control" id="scratchBalancingSelect" onchange="updateBalancingMechanism(true)">
 													<option value="none" selected="selected">None</option>

--- a/src/index.html
+++ b/src/index.html
@@ -1031,11 +1031,10 @@
 											</div>
 											<div class="col-sm-6">
 												<!-- balancing mechanism -->
-												<div
-													class="form-group"
-													data-toggle="tooltip" data-placement="auto" title="The mechanism for balancing first-player advantage. Komi: If the game ends without a road, Black gets this amount added to their final flat count. Double Black Stack: White's initial placement is a stack of two black flats."
-												>
-													<label for="balancingselect">Balancing Mechanism</label>
+												<div class="form-group">
+													<label for="balancingselect">Balancing Mechanism
+														<button type="button" class="btn btn-link p-0 align-baseline" style="line-height:1;vertical-align:middle;" data-toggle="popover" data-trigger="focus" data-placement="top" data-html="true" data-content="The mechanism for balancing first-player advantage.<br><br><b>Komi:</b> If the game ends without a road, Black gets this amount added to their final flat count.<br><br><b>Double Black Stack:</b> White's initial placement is a stack of two black flats." aria-label="Balancing mechanism help">&#9432;</button>
+													</label>
 													<div class="balancing-row">
 														<select class="form-control" id="balancingselect" onchange="updateBalancingMechanism(false)">
 															<option value="none" selected="selected">None</option>
@@ -1225,8 +1224,10 @@
 
 									</div>
 									<div class="col-sm-6">
-										<div class="form-group" data-toggle="tooltip" data-placement="auto" title="The mechanism for balancing first-player advantage. Komi: If the game ends without a road, Black gets this amount added to their final flat count. Double Black Stack: White's initial placement is a stack of two black flats.">
-											<label for="scratchBalancingSelect">Balancing Mechanism</label>
+										<div class="form-group">
+											<label for="scratchBalancingSelect">Balancing Mechanism
+												<button type="button" class="btn btn-link p-0 align-baseline" style="line-height:1;vertical-align:middle;" data-toggle="popover" data-trigger="focus" data-placement="top" data-html="true" data-content="The mechanism for balancing first-player advantage.<br><br><b>Komi:</b> If the game ends without a road, Black gets this amount added to their final flat count.<br><br><b>Double Black Stack:</b> White's initial placement is a stack of two black flats." aria-label="Balancing mechanism help">&#9432;</button>
+											</label>
 											<div class="balancing-row">
 												<select class="form-control" id="scratchBalancingSelect" onchange="updateBalancingMechanism(true)">
 													<option value="none" selected="selected">None</option>

--- a/src/index.html
+++ b/src/index.html
@@ -1099,6 +1099,21 @@
 												</div>
 											</div>
 										</div>
+										<div class="row">
+											<div class="col-sm-6">
+												<!-- opening -->
+												<div
+													class="form-group"
+													data-toggle="tooltip" data-placement="auto" title="Opening - Single Swap: each player's first move places one of the opponent's flats. Double Black Stack: White's first move instead places a stack of two black flats."
+												>
+													<label for="openingselect">Opening</label>
+													<select class="form-control" id="openingselect">
+														<option value="swap" selected="selected">Single Swap</option>
+														<option value="double black stack">Double Black Stack</option>
+													</select>
+												</div>
+											</div>
+										</div>
 										<div class="accordion" id="accordionExample">
 											<div class="card">
 												<div class="card-header" id="headingOne">
@@ -1221,6 +1236,15 @@
 											</select>
 										</div>
 
+									</div>
+									<div class="col-sm-6">
+										<div class="form-group" data-toggle="tooltip" data-placement="auto" title="Opening - Single Swap: each player's first move places one of the opponent's flats. Double Black Stack: white's first move instead places a stack of two black flats.">
+											<label for="scratchOpeningSelect">Opening</label>
+											<select class="form-control" id="scratchOpeningSelect">
+												<option value="swap" selected="selected">Single Swap</option>
+												<option value="double black stack">Double Black Stack</option>
+											</select>
+										</div>
 									</div>
 								</div>
 								<div class="row">
@@ -2189,6 +2213,7 @@
 									<td class="right hide-sm">Stones</td>
 									<td class="right hide-sm">Type</td>
 									<td class="right hide-sm">Extra</td>
+									<td class="right hide-sm">Opening</td>
 									<td class="right hide-md" style="width: 40px"></td>
 								</tr>
 							</thead>
@@ -2208,6 +2233,7 @@
 									<td class="right hide-sm">Stones</td>
 									<td class="right hide-sm">Type</td>
 									<td class="right hide-sm">Extra</td>
+									<td class="right hide-sm">Opening</td>
 									<td class="right hide-md" style="width: 40px"></td>
 								</tr>
 							</thead>

--- a/src/index.html
+++ b/src/index.html
@@ -285,7 +285,7 @@
 						class="rulebox"
 						data-toggle="tooltip" data-placement="auto" title="Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined"
 					></span>
-					|
+					<span id="komi-separator">|</span>
 					<span
 						id="piecerule"
 						class="rulebox"
@@ -1030,23 +1030,24 @@
 												</div>
 											</div>
 											<div class="col-sm-6">
-												<!-- komi -->
+												<!-- balancing mechanism -->
 												<div
 													class="form-group"
-													data-toggle="tooltip" data-placement="auto" title="Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined. 2 is the generally agreed-upon value"
+													data-toggle="tooltip" data-placement="auto" title="The mechanism for balancing first-player advantage. Komi: If the game ends without a road, Black gets this amount added to their final flat count. Double Black Stack: White's initial placement is a stack of two black flats."
 												>
-													<label for="komiselect">Komi</label>
-													<select class="form-control" id="komiselect">
-														<option value="0" selected="selected">0</option>
-														<option value="1">&frac12;</option>
-														<option value="2">1</option>
-														<option value="3">1&frac12;</option>
-														<option value="4">2</option>
-														<option value="5">2&frac12;</option>
-														<option value="6">3</option>
-														<option value="7">3&frac12;</option>
-														<option value="8">4</option>
-													</select>
+													<label for="balancingselect">Balancing Mechanism</label>
+													<div class="balancing-row">
+														<select class="form-control" id="balancingselect" onchange="updateBalancingMechanism(false)">
+															<option value="none" selected="selected">None</option>
+															<option value="komi">Komi</option>
+															<option value="double black stack">Double Black Stack</option>
+														</select>
+														<div class="komi-stepper" id="komiStepper" style="display: none;">
+															<button type="button" class="komi-step-btn" onclick="stepKomi(false, -0.5)" aria-label="Decrease komi value">&minus;</button>
+															<span class="komi-step-value" id="komiValue">2</span>
+															<button type="button" class="komi-step-btn" onclick="stepKomi(false, 0.5)" aria-label="Increase komi value">+</button>
+														</div>
+													</div>
 												</div>
 											</div>
 										</div>
@@ -1100,23 +1101,7 @@
 													</select>
 												</div>
 											</div>
-										</div>
-										<div class="row">
-											<div class="col-sm-6">
-												<!-- opening -->
-												<div
-													class="form-group"
-													data-toggle="tooltip" data-placement="auto" title="Opening - Single Swap: each player's first move places one of the opponent's flats. Double Black Stack: White's first move instead places a stack of two black flats."
-												>
-													<label for="openingselect">Opening</label>
-													<select class="form-control" id="openingselect">
-														<option value="swap" selected="selected">Single Swap</option>
-														<option value="double black stack">Double Black Stack</option>
-													</select>
-												</div>
-											</div>
-										</div>
-										<div class="accordion" id="accordionExample">
+										</div>										<div class="accordion" id="accordionExample">
 											<div class="card">
 												<div class="card-header" id="headingOne">
 													<h2 class="margin--0">
@@ -1240,12 +1225,20 @@
 
 									</div>
 									<div class="col-sm-6">
-										<div class="form-group" data-toggle="tooltip" data-placement="auto" title="Opening - Single Swap: each player's first move places one of the opponent's flats. Double Black Stack: white's first move instead places a stack of two black flats.">
-											<label for="scratchOpeningSelect">Opening</label>
-											<select class="form-control" id="scratchOpeningSelect">
-												<option value="swap" selected="selected">Single Swap</option>
-												<option value="double black stack">Double Black Stack</option>
-											</select>
+										<div class="form-group" data-toggle="tooltip" data-placement="auto" title="The mechanism for balancing first-player advantage. Komi: If the game ends without a road, Black gets this amount added to their final flat count. Double Black Stack: White's initial placement is a stack of two black flats.">
+											<label for="scratchBalancingSelect">Balancing Mechanism</label>
+											<div class="balancing-row">
+												<select class="form-control" id="scratchBalancingSelect" onchange="updateBalancingMechanism(true)">
+													<option value="none" selected="selected">None</option>
+													<option value="komi">Komi</option>
+													<option value="double black stack">Double Black Stack</option>
+												</select>
+												<div class="komi-stepper" id="scratchKomiStepper" style="display: none;">
+													<button type="button" class="komi-step-btn" onclick="stepKomi(true, -0.5)" aria-label="Decrease komi value">&minus;</button>
+													<span class="komi-step-value" id="scratchKomiValue">2</span>
+													<button type="button" class="komi-step-btn" onclick="stepKomi(true, 0.5)" aria-label="Increase komi value">+</button>
+												</div>
+											</div>
 										</div>
 									</div>
 								</div>

--- a/src/index.html
+++ b/src/index.html
@@ -1076,7 +1076,9 @@
 											<div class="col-sm-6">
 												<!-- time inc -->
 												<div class="form-group">
-													<label for="incselect">Increment (seconds)</label>
+													<label for="incselect">Increment (seconds)
+														<button type="button" class="btn btn-link p-0 align-baseline" style="line-height:1;vertical-align:middle;" data-toggle="popover" data-trigger="focus" data-placement="auto" data-html="true" data-content="The increment is the time added to your clock after each move.<br><br><b>n</b> = the current move number. Pick <b>n</b> to make the increment grow each move: move&nbsp;1 = +1s, move&nbsp;2 = +2s, move&nbsp;3 = +3s&hellip; <b>2n</b> doubles it (+2s, +4s, +6s&hellip;).<br><br>A fixed number like <b>20</b> adds the same amount every move." aria-label="Increment scaling help">&#9432;</button>
+													</label>
 													<select class="form-control" id="incselect">
 														<option value="0">0</option>
 														<option value="1">1</option>

--- a/src/index.html
+++ b/src/index.html
@@ -285,7 +285,7 @@
 						class="rulebox"
 						data-toggle="tooltip" data-placement="auto" title="Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined"
 					></span>
-					<span id="komi-separator">|</span>
+					|
 					<span
 						id="piecerule"
 						class="rulebox"
@@ -1030,24 +1030,23 @@
 												</div>
 											</div>
 											<div class="col-sm-6">
-												<!-- balancing mechanism -->
+												<!-- komi -->
 												<div
 													class="form-group"
-													data-toggle="tooltip" data-placement="auto" title="The mechanism for balancing first-player advantage. Komi: If the game ends without a road, Black gets this amount added to their final flat count. Double Black Stack: White's initial placement is a stack of two black flats."
+													data-toggle="tooltip" data-placement="auto" title="Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined. 2 is the generally agreed-upon value"
 												>
-													<label for="balancingselect">Balancing Mechanism</label>
-													<div class="balancing-row">
-														<select class="form-control" id="balancingselect" onchange="updateBalancingMechanism(false)">
-															<option value="none" selected="selected">None</option>
-															<option value="komi">Komi</option>
-															<option value="double black stack">Double Black Stack</option>
-														</select>
-														<div class="komi-stepper" id="komiStepper" style="display: none;">
-															<button type="button" class="komi-step-btn" onclick="stepKomi(false, -0.5)" aria-label="Decrease komi value">&minus;</button>
-															<span class="komi-step-value" id="komiValue">2</span>
-															<button type="button" class="komi-step-btn" onclick="stepKomi(false, 0.5)" aria-label="Increase komi value">+</button>
-														</div>
-													</div>
+													<label for="komiselect">Komi</label>
+													<select class="form-control" id="komiselect">
+														<option value="0" selected="selected">0</option>
+														<option value="1">&frac12;</option>
+														<option value="2">1</option>
+														<option value="3">1&frac12;</option>
+														<option value="4">2</option>
+														<option value="5">2&frac12;</option>
+														<option value="6">3</option>
+														<option value="7">3&frac12;</option>
+														<option value="8">4</option>
+													</select>
 												</div>
 											</div>
 										</div>
@@ -1101,7 +1100,23 @@
 													</select>
 												</div>
 											</div>
-										</div>										<div class="accordion" id="accordionExample">
+										</div>
+										<div class="row">
+											<div class="col-sm-6">
+												<!-- opening -->
+												<div
+													class="form-group"
+													data-toggle="tooltip" data-placement="auto" title="Opening - Single Swap: each player's first move places one of the opponent's flats. Double Black Stack: White's first move instead places a stack of two black flats."
+												>
+													<label for="openingselect">Opening</label>
+													<select class="form-control" id="openingselect">
+														<option value="swap" selected="selected">Single Swap</option>
+														<option value="double black stack">Double Black Stack</option>
+													</select>
+												</div>
+											</div>
+										</div>
+										<div class="accordion" id="accordionExample">
 											<div class="card">
 												<div class="card-header" id="headingOne">
 													<h2 class="margin--0">
@@ -1225,20 +1240,12 @@
 
 									</div>
 									<div class="col-sm-6">
-										<div class="form-group" data-toggle="tooltip" data-placement="auto" title="The mechanism for balancing first-player advantage. Komi: If the game ends without a road, Black gets this amount added to their final flat count. Double Black Stack: White's initial placement is a stack of two black flats.">
-											<label for="scratchBalancingSelect">Balancing Mechanism</label>
-											<div class="balancing-row">
-												<select class="form-control" id="scratchBalancingSelect" onchange="updateBalancingMechanism(true)">
-													<option value="none" selected="selected">None</option>
-													<option value="komi">Komi</option>
-													<option value="double black stack">Double Black Stack</option>
-												</select>
-												<div class="komi-stepper" id="scratchKomiStepper" style="display: none;">
-													<button type="button" class="komi-step-btn" onclick="stepKomi(true, -0.5)" aria-label="Decrease komi value">&minus;</button>
-													<span class="komi-step-value" id="scratchKomiValue">2</span>
-													<button type="button" class="komi-step-btn" onclick="stepKomi(true, 0.5)" aria-label="Increase komi value">+</button>
-												</div>
-											</div>
+										<div class="form-group" data-toggle="tooltip" data-placement="auto" title="Opening - Single Swap: each player's first move places one of the opponent's flats. Double Black Stack: white's first move instead places a stack of two black flats.">
+											<label for="scratchOpeningSelect">Opening</label>
+											<select class="form-control" id="scratchOpeningSelect">
+												<option value="swap" selected="selected">Single Swap</option>
+												<option value="double black stack">Double Black Stack</option>
+											</select>
 										</div>
 									</div>
 								</div>

--- a/src/index.html
+++ b/src/index.html
@@ -2208,12 +2208,9 @@
 									<th>Player</th>
 									<td class="right">Rating</td>
 									<td class="right ">Board</td>
-									<td class="right">Time</td>
-									<td class="right">Komi</td>
-									<td class="right hide-sm">Stones</td>
-									<td class="right hide-sm">Type</td>
-									<td class="right hide-sm">Extra</td>
-									<td class="right hide-sm">Opening</td>
+									<td class="time-rule">Time</td>
+									<td class="rules-rule">Rules</td>
+									<td class="hide-sm">Type</td>
 									<td class="right hide-md" style="width: 40px"></td>
 								</tr>
 							</thead>
@@ -2228,12 +2225,9 @@
 									<th>AI</th>
 									<td class="right">Rating</td>
 									<td class="right">Board</td>
-									<td class="right time-rule">Time</td>
-									<td class="right komi-rule">Komi</td>
-									<td class="right hide-sm">Stones</td>
-									<td class="right hide-sm">Type</td>
-									<td class="right hide-sm">Extra</td>
-									<td class="right hide-sm">Opening</td>
+									<td class="time-rule">Time</td>
+									<td class="rules-rule">Rules</td>
+									<td class="hide-sm">Type</td>
 									<td class="right hide-md" style="width: 40px"></td>
 								</tr>
 							</thead>
@@ -2260,11 +2254,9 @@
 									<td></td>
 									<td class="text-center">Players</td>
 									<td class="right">Board</td>
-									<td class="right time-rule">Time</td>
-									<td class="right komi-rule">Komi</td>
-									<td class="right hide-sm">Stones</td>
-									<td class="right hide-sm">Type</td>
-									<td class="right hide-sm">Extra</td>
+									<td class="time-rule">Time</td>
+									<td class="rules-rule">Rules</td>
+									<td class="hide-sm">Type</td>
 									<td class="right hide-md" style="width: 40px"></td>
 								</tr>
 							</thead>

--- a/src/index.html
+++ b/src/index.html
@@ -1077,7 +1077,7 @@
 												<!-- time inc -->
 												<div class="form-group">
 													<label for="incselect">Increment (seconds)
-														<button type="button" class="btn btn-link p-0 align-baseline" style="line-height:1;vertical-align:middle;" data-toggle="popover" data-trigger="focus" data-placement="auto" data-html="true" data-content="The increment is the time added to your clock after each move.<br><br><b>n</b> = the current move number. Pick <b>n</b> to make the increment grow each move: move&nbsp;1 = +1s, move&nbsp;2 = +2s, move&nbsp;3 = +3s&hellip; <b>2n</b> doubles it (+2s, +4s, +6s&hellip;).<br><br>A fixed number like <b>20</b> adds the same amount every move." aria-label="Increment scaling help">&#9432;</button>
+														<button type="button" class="btn btn-link p-0 align-baseline" style="line-height:1;vertical-align:middle;" data-toggle="popover" data-trigger="focus" data-placement="top" data-html="true" data-content="The increment is the time added to your clock after each move.<br><br><b>n</b> = the current move number. Pick <b>n</b> to make the increment grow each move: move&nbsp;1 = +1s, move&nbsp;2 = +2s, move&nbsp;3 = +3s&hellip; <b>2n</b> doubles it (+2s, +4s, +6s&hellip;).<br><br>A fixed number like <b>20</b> adds the same amount every move." aria-label="Increment scaling help">&#9432;</button>
 													</label>
 													<select class="form-control" id="incselect">
 														<option value="0">0</option>

--- a/src/js/2d-board.js
+++ b/src/js/2d-board.js
@@ -80,7 +80,16 @@ async function messageHandler(event){
 				server.send("Game#" + gameData.id + " " + fromPTN(value));
 				setDisable2DBoard(true);
 			}
-			notate(value);
+			// Double Black Stack: white's first ply is written "2a1". PTN Ninja
+			// emits a plain "a1" for the placement, so add the leading "2"
+			// ourselves (idempotent — mirrors board.js notatePmove and
+			// server.js processGameMove). The server send above is unaffected:
+			// fromPTN ignores a placement's leading count.
+			let plyNotation = value;
+			if(gameData.opening === 'double black stack' && gameData.move_count === 0 && !/^2/.test(plyNotation)){
+				plyNotation = '2' + plyNotation;
+			}
+			notate(plyNotation);
 			incrementMoveCounter();
 			storeNotation();
 			// Play sound: if animations enabled, delay to sync with PTN Ninja animation

--- a/src/js/board.js
+++ b/src/js/board.js
@@ -2423,7 +2423,7 @@ const board = {
 	},
 	placePieceOnSquare: function(piece, sq, hideSelectionShadowAfter){
 		const self = this;
-		// Double Black Stack: white's first move places a second black flat on top,
+		// Double Black Stack (DBS): white's first move places a second black flat on top,
 		// animated together with the first flat so the pair moves down as a unit.
 		// select() sets selectedCompanion for the lift-then-place flow; the direct
 		// click-to-place flow skips select(), so resolve the companion here too
@@ -2486,7 +2486,7 @@ const board = {
 		// If no lifted companion was animated above (e.g. a fallback path), add the
 		// extra black flat now. The own-move flow normally handles it inline above.
 		if(!companion){
-			this.maybeAddDoubleBlackStackFlat(sq);
+			this.addDoubleBlackStackFlatIfApplicable(sq);
 		}
 		this.incmovecnt();
 	},
@@ -2511,7 +2511,7 @@ const board = {
 	// on top of the swapped black flat, drawn from black's reserves (rendered "2a1").
 	// Must run after the first flat is on the square and before the position snapshot
 	// (incmovecnt) so board_history captures both flats.
-	maybeAddDoubleBlackStackFlat: function(sq){
+	addDoubleBlackStackFlatIfApplicable: function(sq){
 		if(gameData.opening !== 'double black stack' || gameData.move_count !== 0){
 			return;
 		}
@@ -2607,7 +2607,7 @@ const board = {
 
 		// Only fall back to the teleport helper when no companion was animated above.
 		if(!companion){
-			this.maybeAddDoubleBlackStackFlat(hlt);
+			this.addDoubleBlackStackFlatIfApplicable(hlt);
 		}
 		this.notatePmove(file + rank,caporwall);
 		this.incmovecnt();

--- a/src/js/board.js
+++ b/src/js/board.js
@@ -841,14 +841,30 @@ const pieceFactory = {
 		const materialMine = (playerNum === WHITE_PLAYER ? materials.white_piece : materials.black_piece);
 		const geometry=piecegeometry(playerNum === WHITE_PLAYER?"white":"black");
 
-		const stackno = Math.floor(pieceNum / 10);
-		const stackheight = pieceNum % 10;
+		let stackno = Math.floor(pieceNum / 10);
+		let stackheight = pieceNum % 10;
 		const piece = new THREE.Mesh(geometry,materialMine);
 		piece.iswhitepiece = (playerNum === WHITE_PLAYER);
 		// Swap first-to-play flat stone positions for first turn rule
 		// getfromstack returns the highest pieceNum first, so tottiles-1 is first to play
 		const firstToPlayPieceNum = board.tottiles - 1;
-		const isFirstToPlay = (pieceNum === firstToPlayPieceNum);
+		let isFirstToPlay = (pieceNum === firstToPlayPieceNum);
+		// Double Black Stack: white's first move places TWO black flats, so stage a
+		// second black flat (the extra drawn from black's reserves) on white's side,
+		// resting directly on top of the first swapped black flat so both are visible
+		// (rather than at this piece's own reserve slot, which would overlap white's).
+		if(gameData.opening === 'double black stack' && playerNum === BLACK_PLAYER && pieceNum === firstToPlayPieceNum - 1){
+			isFirstToPlay = true;
+			stackno = Math.floor(firstToPlayPieceNum / 10);
+			stackheight = (firstToPlayPieceNum % 10) + 1;
+		}
+		// Double Black Stack: black donates an extra flat to white's opening stack, so
+		// black's reserve pile is one shorter. The white first-to-play flat that rests
+		// on top of black's reserves must drop a level so it doesn't float over the gap.
+		// (Only when that flat shares a column with the donated flat, i.e. not at a column base.)
+		if(gameData.opening === 'double black stack' && playerNum === WHITE_PLAYER && pieceNum === firstToPlayPieceNum && (firstToPlayPieceNum % 10) > 0){
+			stackheight = (firstToPlayPieceNum % 10) - 1;
+		}
 		const positionAsWhite = (playerNum === WHITE_PLAYER) !== isFirstToPlay;
 		const invertBlackZ = shouldInvertBlackPiecesZ();
 		if(positionAsWhite){
@@ -1540,6 +1556,7 @@ const board = {
 	totalhighlighted: null,
 	selected: null,
 	selectedStack: null,
+	selectedCompanion: null, // Double Black Stack: the second black flat lifted with the first
 	boardside: "white",
 	overlay: null,
 	isBot: false,
@@ -1591,6 +1608,7 @@ const board = {
 		this.lastMoveHighlighted = null;
 		this.selected = null;
 		this.selectedStack = null;
+		this.selectedCompanion = null;
 		this.move = {start: null, end: null, dir: 'U', squares: []};
 		//gameData.observing = typeof obs !== 'undefined' ? obs : false
 		this.board_history = [];
@@ -2405,17 +2423,34 @@ const board = {
 	},
 	placePieceOnSquare: function(piece, sq, hideSelectionShadowAfter){
 		const self = this;
-		animation.push([piece]);
+		// Double Black Stack: white's first move places a second black flat on top,
+		// animated together with the first flat so the pair moves down as a unit.
+		// select() sets selectedCompanion for the lift-then-place flow; the direct
+		// click-to-place flow skips select(), so resolve the companion here too
+		// (otherwise the second flat teleports instead of animating). Falls back to
+		// null for non-DBS moves, so the single-piece path is unchanged.
+		const companion = this.selectedCompanion || this.getDoubleBlackStackCompanion();
+		const movers = companion ? [piece, companion] : [piece];
+		animation.push(movers);
 		if(piece.aoPlane && animationsEnabled){
 			piece.aoPlane.fadeIn = true;
 			piece.aoPlane.material.opacity = 0;
 		}
 		this.pushPieceOntoSquare(sq, piece);
+		if(companion){
+			if(companion.aoPlane && animationsEnabled){
+				companion.aoPlane.fadeIn = true;
+				companion.aoPlane.material.opacity = 0;
+			}
+			this.pushPieceOntoSquare(sq, companion);
+			this.blackpiecesleft--;
+			this.selectedCompanion = null;
+		}
 		if(hideSelectionShadowAfter){
-			animation.push([piece], 'jump', 300, function(){self.hideSelectionShadow();});
+			animation.push(movers, 'jump', 300, function(){self.hideSelectionShadow();});
 		}
 		else{
-			animation.push([piece], 'jump', 300);
+			animation.push(movers, 'jump', 300);
 		}
 		animation.play(playMoveSound);
 
@@ -2448,6 +2483,11 @@ const board = {
 				}
 			}
 		}
+		// If no lifted companion was animated above (e.g. a fallback path), add the
+		// extra black flat now. The own-move flow normally handles it inline above.
+		if(!companion){
+			this.maybeAddDoubleBlackStackFlat(sq);
+		}
 		this.incmovecnt();
 	},
 	// Get the swapped first-turn piece (opponent's color positioned on player's side)
@@ -2462,6 +2502,37 @@ const board = {
 			if(!obj.onsquare && !obj.iscapstone &&
 					obj.pieceNum === targetPieceNum &&
 					obj.iswhitepiece === wantWhitePiece){
+				return obj;
+			}
+		}
+		return null;
+	},
+	// Double Black Stack opening: on white's first move, place a second black flat
+	// on top of the swapped black flat, drawn from black's reserves (rendered "2a1").
+	// Must run after the first flat is on the square and before the position snapshot
+	// (incmovecnt) so board_history captures both flats.
+	maybeAddDoubleBlackStackFlat: function(sq){
+		if(gameData.opening !== 'double black stack' || gameData.move_count !== 0){
+			return;
+		}
+		const obj = this.getfromstack(false, false); // a black flat
+		if(!obj){
+			return;
+		}
+		obj.isFirstTurnPiece = true;
+		this.pushPieceOntoSquare(sq, obj);
+		this.blackpiecesleft--;
+	},
+	// The second staged black flat (pieceNum tottiles-2) for the Double Black Stack
+	// opening — the companion that lifts/lowers/places together with the first flat.
+	getDoubleBlackStackCompanion: function(){
+		if(gameData.opening !== 'double black stack' || gameData.move_count !== 0){
+			return null;
+		}
+		const targetPieceNum = this.tottiles - 2;
+		for(let i = 0; i < this.piece_objects.length; i++){
+			const obj = this.piece_objects[i];
+			if(!obj.onsquare && !obj.iscapstone && !obj.iswhitepiece && obj.pieceNum === targetPieceNum){
 				return obj;
 			}
 		}
@@ -2488,6 +2559,11 @@ const board = {
 			obj.isFirstTurnPiece = true;
 		}
 
+		// Double Black Stack: on the opponent's screen, white's first move places a
+		// second black flat that must animate together with the first (same frame).
+		const companion = this.getDoubleBlackStackCompanion();
+		if(companion){ companion.isFirstTurnPiece = true; }
+
 		const hlt = this.get_board_obj(file.charCodeAt(0) - 'A'.charCodeAt(0),rank - 1);
 		if(skipAnimation || oldpos !== -1){
 			// Just place the piece without animation (loading history or viewing earlier position)
@@ -2495,6 +2571,10 @@ const board = {
 				this.standup(obj);
 			}
 			this.pushPieceOntoSquare(hlt,obj);
+			if(companion){
+				this.pushPieceOntoSquare(hlt, companion);
+				this.blackpiecesleft--;
+			}
 			// Still play sound if viewing earlier position (not loading history)
 			if(oldpos !== -1 && !skipAnimation){
 				playMoveSound();
@@ -2503,21 +2583,32 @@ const board = {
 		else{
 			// Enable drop shadow during animation
 			obj.castShadow = true;
+			if(companion){ companion.castShadow = true; }
+			const movers = companion ? [obj, companion] : [obj];
 			// Record start position before any changes
-			animation.push([obj]);
+			animation.push(movers);
 			// Apply standup rotation if wall
 			if(caporwall === 'W'){
 				this.standup(obj);
 			}
 			this.pushPieceOntoSquare(hlt,obj);
-			animation.push([obj], 'jump', 300, function(){
+			if(companion){
+				this.pushPieceOntoSquare(hlt, companion);
+				this.blackpiecesleft--;
+			}
+			animation.push(movers, 'jump', 300, function(){
 				obj.castShadow = false;
+				if(companion){ companion.castShadow = false; }
 			});
 			animation.play(playMoveSound);
 		}
 		this.highlightLastMove_sq(hlt, gameData.move_count);
 		this.lastMovedSquareList.push({file: hlt.file, rank: hlt.rank});
 
+		// Only fall back to the teleport helper when no companion was animated above.
+		if(!companion){
+			this.maybeAddDoubleBlackStackFlat(hlt);
+		}
 		this.notatePmove(file + rank,caporwall);
 		this.incmovecnt();
 
@@ -2790,7 +2881,9 @@ const board = {
 		if(pos === 'W'){pos = 'S';}
 		else if(pos === 'C'){pos = 'C';}
 		else{pos = '';}
-		notate(pos + sqname.toLowerCase());
+		// Double Black Stack: white's first ply is written "2a1"
+		const dbsPrefix = (gameData.opening === 'double black stack' && gameData.move_count === 0) ? '2' : '';
+		notate(dbsPrefix + pos + sqname.toLowerCase());
 		storeNotation();
 	},
 	//all params are nums
@@ -3143,7 +3236,11 @@ const board = {
 		return 'OUTSIDE';
 	},
 	select: function(obj){
-		animation.push([obj]);
+		// Double Black Stack: lift the companion black flat together with the first flat.
+		const companion = this.getDoubleBlackStackCompanion();
+		const dbsCompanion = (companion && companion !== obj) ? companion : null;
+		const movers = dbsCompanion ? [obj, dbsCompanion] : [obj];
+		animation.push(movers);
 		// Reposition unplayed pieces to correct location before lifting
 		// (piece_size may have changed since piece was created)
 		if(!obj.onsquare){
@@ -3170,7 +3267,11 @@ const board = {
 			}
 			else{
 				const stackno = Math.floor(obj.pieceNum / 10);
-				const stackheight = obj.pieceNum % 10;
+				let stackheight = obj.pieceNum % 10;
+				// Double Black Stack: white's first-to-play flat rests one lower (black donated a flat).
+				if(gameData.opening === 'double black stack' && obj.iswhitepiece && obj.pieceNum === board.tottiles - 1 && ((board.tottiles - 1) % 10) > 0){
+					stackheight -= 1;
+				}
 				const baseY = obj.isstanding ? (piece_size/2-sq_height/2) : (stackheight*piece_height+piece_height/2-sq_height/2);
 				const posAsWhite = obj.positionAsWhite !== undefined ? obj.positionAsWhite : obj.iswhitepiece;
 				if(posAsWhite){
@@ -3197,6 +3298,12 @@ const board = {
 			obj.position.y += stack_selection_height;
 		}
 		this.selected = obj;
+		// Lift the Double Black Stack companion by the same amount so it stays stacked on top.
+		if(dbsCompanion){
+			dbsCompanion.position.y += stack_selection_height;
+			if(dbsCompanion.aoPlane){ dbsCompanion.aoPlane.material.opacity = 0; }
+			this.selectedCompanion = dbsCompanion;
+		}
 		this.showSelectionShadow(obj);
 		// Fade out AO shadow when lifting
 		if(obj.aoPlane && animationsEnabled){
@@ -3217,7 +3324,7 @@ const board = {
 				pieceBelow.aoPlane.material.opacity = shouldShowBelow ? 1.0 : 0;
 			}
 		}
-		animation.push([obj], 'move', 100);
+		animation.push(movers, 'move', 100);
 		animation.play();
 	},
 	unselect: function(options){
@@ -3225,7 +3332,10 @@ const board = {
 		if(this.selected){
 			const self = this;
 			const piece = this.selected;
-			animate && animation.push([piece]);
+			// Double Black Stack: lower the companion black flat together with the first.
+			const companion = this.selectedCompanion;
+			const movers = companion ? [piece, companion] : [piece];
+			animate && animation.push(movers);
 			// If piece is standing (wall), flatten it back and adjust height accordingly
 			if(piece.isstanding && !piece.iscapstone){
 				piece.position.y -= stack_selection_height + (piece_size / 2 - piece_height / 2);
@@ -3239,6 +3349,14 @@ const board = {
 			}
 			else{
 				piece.position.y -= stack_selection_height;
+			}
+			if(companion){
+				companion.position.y -= stack_selection_height;
+				if(companion.aoPlane){
+					companion.aoPlane.visible = shadowsEnabled;
+					companion.aoPlane.fadeIn = shadowsEnabled;
+					companion.aoPlane.material.opacity = 0;
+				}
 			}
 			// Restore AO visibility for unplayed pieces being dropped back
 			if(piece.aoPlane && !piece.onsquare){
@@ -3255,15 +3373,20 @@ const board = {
 					stack[pieceIndex - 1].aoPlane.material.opacity = 0;
 				}
 			}
-			animate && animation.push([piece], 'move', 75, function(){
+			animate && animation.push(movers, 'move', 75, function(){
 				self.hideSelectionShadow();
 				// Ensure AO is visible after animation completes
 				if(piece.aoPlane && !piece.onsquare){
 					piece.aoPlane.material.opacity = 1.0;
 					piece.aoPlane.fadeIn = false;
 				}
+				if(companion && companion.aoPlane && !companion.onsquare){
+					companion.aoPlane.material.opacity = 1.0;
+					companion.aoPlane.fadeIn = false;
+				}
 			});
 			this.selected = null;
+			this.selectedCompanion = null;
 			if(!animate){
 				this.hideSelectionShadow();
 				if(piece.aoPlane && !piece.onsquare){
@@ -3346,10 +3469,17 @@ const board = {
 		if(this.selected && !this.selected.onsquare){
 			const piece = this.selected;
 			const needsFlatten = piece.isstanding && !piece.iscapstone;
+			// Double Black Stack: lower the companion black flat together with the first.
+			const companion = this.selectedCompanion;
+			const movers = companion ? [piece, companion] : [piece];
 			// Record current position for animation start
-			animation.push([piece]);
+			animation.push(movers);
 			// Calculate absolute final position (not relative to current)
-			const stackheight = piece.pieceNum % 10;
+			let stackheight = piece.pieceNum % 10;
+			// Double Black Stack: white's first-to-play flat rests one lower (black donated a flat).
+			if(gameData.opening === 'double black stack' && piece.iswhitepiece && piece.pieceNum === board.tottiles - 1 && ((board.tottiles - 1) % 10) > 0){
+				stackheight -= 1;
+			}
 			let finalY;
 			if(piece.iscapstone){
 				finalY = capstone_height/2 - sq_height/2;
@@ -3379,8 +3509,17 @@ const board = {
 					piece.aoPlane.material.opacity = 0;
 				}
 			}
+			// Lower the companion back to its staged position (one level above the
+			// first flat's rest slot) by reversing the selection lift.
+			if(companion){
+				companion.position.y -= stack_selection_height;
+				if(companion.aoPlane){
+					companion.aoPlane.visible = false;
+					companion.aoPlane.material.opacity = 0;
+				}
+			}
 			const self = this;
-			animation.push([piece], 'move', 100, function(){
+			animation.push(movers, 'move', 100, function(){
 				self.hideSelectionShadow();
 				// Ensure AO is visible after animation completes (only for bottom pieces)
 				if(piece.aoPlane && isBottomOfStack){
@@ -3390,6 +3529,7 @@ const board = {
 			});
 			animation.play();
 			this.selected = null;
+			this.selectedCompanion = null;
 			return;
 		}
 		// Animate selected stack back to starting position

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -863,9 +863,9 @@ function handleGameOverState(){
 		if(!is2DBoard){
 			gameData.flatCount = board.flatscore();
 		}
-		let komi = (Math.floor(gameData.komi / 2) || (gameData.komi & 1 ? "" : "0")) + (gameData.komi & 1 ? "&frac12;" : "");
-		if(komi){
-			komi = "+" + komi;
+		let komi = "";
+		if(gameData.komi > 0){
+			komi = "+" + ((Math.floor(gameData.komi / 2) || (gameData.komi & 1 ? "" : "0")) + (gameData.komi & 1 ? "&frac12;" : ""));
 		}
 		type = "having more top flats (" + gameData.flatCount[0] + " to " + gameData.flatCount[1] + komi + ")";
 	}

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -103,8 +103,9 @@ function playScratch(){
 		gameData.size = parseInt(document.getElementById("scratchBoardSize").value);
 		gameData.pieces = parseInt(document.getElementById("scratchPieceCount").value);
 		gameData.capstones = parseInt(document.getElementById("scratchCapCount").value);
-		gameData.opening = document.getElementById("scratchOpeningSelect").value;
-		gameData.komi = 0;
+		const balancing = getBalancingValues(true);
+		gameData.opening = balancing.opening;
+		gameData.komi = balancing.komi;
 		gameData.id = 0;
 		initBoard();
 		if(is2DBoard){
@@ -119,7 +120,14 @@ function playScratch(){
 }
 
 function initBoard(){
-	$("#komirule").html("+" + (Math.floor(gameData.komi / 2) || (gameData.komi & 1 ? "" : "0")) + (gameData.komi & 1 ? "&frac12;" : ""));
+	if(gameData.komi > 0){
+		$("#komirule").html("+" + (Math.floor(gameData.komi / 2) || (gameData.komi & 1 ? "" : "0")) + (gameData.komi & 1 ? "&frac12;" : "")).css("display", "");
+		$("#komi-separator").css("display", "");
+	}
+	else{
+		$("#komirule").html("").css("display", "none");
+		$("#komi-separator").css("display", "none");
+	}
 	$("#piecerule").html(gameData.pieces + "/" + gameData.capstones);
 	document.getElementById("player-opp").className = "selectplayer";
 	document.getElementById("player-me").className = "";

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -65,6 +65,7 @@ function resetGameDataToDefault(){
 		capstones: 1,
 		unrated: false,
 		tournament: false,
+		opening: 'swap',
 		triggerMove: 0,
 		timeAmount: 0,
 		bot: 0,
@@ -102,6 +103,7 @@ function playScratch(){
 		gameData.size = parseInt(document.getElementById("scratchBoardSize").value);
 		gameData.pieces = parseInt(document.getElementById("scratchPieceCount").value);
 		gameData.capstones = parseInt(document.getElementById("scratchCapCount").value);
+		gameData.opening = document.getElementById("scratchOpeningSelect").value;
 		gameData.komi = 0;
 		gameData.id = 0;
 		initBoard();
@@ -154,7 +156,7 @@ function initBoard(){
 		board.initEmpty();
 		return;
 	}
-	set2DBoard(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]`);
+	set2DBoard(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]${gameData.opening !== 'swap' ? `[Opening "${gameData.opening}"]` : ''}`);
 	if(gameData.my_color === 'black'){
 		setDisable2DBoard(true);
 	}
@@ -788,6 +790,17 @@ function checkIfMyMove(){
 	if(gameData.observing){return false;}
 	const toMove = (gameData.move_count % 2 === 0) ? "white" : "black";
 	return toMove === gameData.my_color;
+}
+
+// Opening variants. The array index is the compact code used on the space-delimited
+// Seek wire protocol; the string is the canonical PTN Ninja "Opening" tag value.
+const OPENING_NAMES = ['swap', 'double black stack'];
+function openingNameFromCode(code){
+	return OPENING_NAMES[code] || 'swap';
+}
+function openingCodeFromName(name){
+	const i = OPENING_NAMES.indexOf(name);
+	return i < 0 ? 0 : i;
 }
 
 function isWhitePieceToMove(){

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -103,9 +103,8 @@ function playScratch(){
 		gameData.size = parseInt(document.getElementById("scratchBoardSize").value);
 		gameData.pieces = parseInt(document.getElementById("scratchPieceCount").value);
 		gameData.capstones = parseInt(document.getElementById("scratchCapCount").value);
-		const balancing = getBalancingValues(true);
-		gameData.opening = balancing.opening;
-		gameData.komi = balancing.komi;
+		gameData.opening = document.getElementById("scratchOpeningSelect").value;
+		gameData.komi = 0;
 		gameData.id = 0;
 		initBoard();
 		if(is2DBoard){
@@ -120,14 +119,7 @@ function playScratch(){
 }
 
 function initBoard(){
-	if(gameData.komi > 0){
-		$("#komirule").html("+" + (Math.floor(gameData.komi / 2) || (gameData.komi & 1 ? "" : "0")) + (gameData.komi & 1 ? "&frac12;" : "")).css("display", "");
-		$("#komi-separator").css("display", "");
-	}
-	else{
-		$("#komirule").html("").css("display", "none");
-		$("#komi-separator").css("display", "none");
-	}
+	$("#komirule").html("+" + (Math.floor(gameData.komi / 2) || (gameData.komi & 1 ? "" : "0")) + (gameData.komi & 1 ? "&frac12;" : ""));
 	$("#piecerule").html(gameData.pieces + "/" + gameData.capstones);
 	document.getElementById("player-opp").className = "selectplayer";
 	document.getElementById("player-me").className = "";

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -496,70 +496,11 @@ function fastforward() {
 function resetFormFieldAttributes() {
 	const form = document.getElementById("create-game-form");
 	// remove the required attribute from all elements
-	const allFields = form.querySelectorAll("input, select, .komi-step-btn");
+	const allFields = form.querySelectorAll("input, select");
 	allFields.forEach((field) => {
 		field.removeAttribute("required");
 		field.removeAttribute("disabled");
 	});
-}
-
-// --- Balancing Mechanism control (None / Komi / Double Black Stack) ---
-// A single selector that maps onto the underlying komi + opening values.
-// komi is stored in half-points (komi / 2 = the points shown to the user).
-function balancingIds(isScratch) {
-	return isScratch
-		? { select: "scratchBalancingSelect", stepper: "scratchKomiStepper", value: "scratchKomiValue" }
-		: { select: "balancingselect", stepper: "komiStepper", value: "komiValue" };
-}
-
-function formatKomiPoints(points) {
-	return Number.isInteger(points) ? String(points) : points.toFixed(1);
-}
-
-// Show the komi stepper only when "Komi" is the selected mechanism.
-function updateBalancingMechanism(isScratch) {
-	const ids = balancingIds(isScratch);
-	const mech = document.getElementById(ids.select).value;
-	document.getElementById(ids.stepper).style.display = mech === "komi" ? "flex" : "none";
-}
-
-// Adjust the komi value by +/- 0.5, clamped to a 0.5 minimum.
-function stepKomi(isScratch, delta) {
-	const ids = balancingIds(isScratch);
-	const el = document.getElementById(ids.value);
-	let points = parseFloat(el.textContent) || 2;
-	points = Math.max(0.5, Math.round((points + delta) * 2) / 2);
-	el.textContent = formatKomiPoints(points);
-}
-
-// Read the control as { komi, opening } in the underlying wire representation.
-function getBalancingValues(isScratch) {
-	const ids = balancingIds(isScratch);
-	const mech = document.getElementById(ids.select).value;
-	if (mech === "komi") {
-		const points = parseFloat(document.getElementById(ids.value).textContent) || 2;
-		return { komi: Math.round(points * 2), opening: "swap" };
-	}
-	if (mech === "double black stack") {
-		return { komi: 0, opening: "double black stack" };
-	}
-	return { komi: 0, opening: "swap" };
-}
-
-// Set the control from underlying komi + opening values (reverse of getBalancingValues).
-function setBalancingValues(isScratch, komi, opening) {
-	const ids = balancingIds(isScratch);
-	const sel = document.getElementById(ids.select);
-	komi = Number(komi) || 0;
-	if (opening === "double black stack") {
-		sel.value = "double black stack";
-	} else if (komi > 0) {
-		sel.value = "komi";
-		document.getElementById(ids.value).textContent = formatKomiPoints(komi / 2);
-	} else {
-		sel.value = "none";
-	}
-	updateBalancingMechanism(isScratch);
 }
 
 function changePreset(event) {
@@ -579,12 +520,13 @@ function changePreset(event) {
 		document.getElementById("boardsize").value = storedValues.size;
 		document.getElementById("piececount").value = storedValues.pieces;
 		document.getElementById("capcount").value = storedValues.capstones;
-		setBalancingValues(false, storedValues.komi, storedValues.opening || "swap");
+		document.getElementById("komiselect").value = storedValues.komi;
 		document.getElementById("gametype").value = storedValues.type;
 		document.getElementById("timeselect").value = storedValues.time;
 		document.getElementById("incselect").value = storedValues.increment;
 		document.getElementById("triggerMove").value = storedValues.trigger_move;
 		document.getElementById("timeAmount").value = storedValues.time_amount;
+		document.getElementById("openingselect").value = storedValues.opening || "swap";
 		return;
 	} else if (preset) {
 		// store the current values if user changes back to the noen preset
@@ -592,13 +534,13 @@ function changePreset(event) {
 			size: document.getElementById("boardsize").value,
 			pieces: document.getElementById("piececount").value,
 			capstones: document.getElementById("capcount").value,
-			komi: getBalancingValues(false).komi,
+			komi: document.getElementById("komiselect").value,
 			type: document.getElementById("gametype").value,
 			time: document.getElementById("timeselect").value,
 			increment: document.getElementById("incselect").value,
 			trigger_move: document.getElementById("triggerMove").value,
 			time_amount: document.getElementById("timeAmount").value,
-			opening: getBalancingValues(false).opening,
+			opening: document.getElementById("openingselect").value,
 		};
 		localStorage.setItem(
 			"current-game-settings",
@@ -610,9 +552,8 @@ function changePreset(event) {
 		document.getElementById("piececount").setAttribute("disabled", "true");
 		document.getElementById("capcount").value = preset.capstones;
 		document.getElementById("capcount").setAttribute("disabled", "true");
-		setBalancingValues(false, preset.komi, "swap");
-		document.getElementById("balancingselect").setAttribute("disabled", "true");
-		document.querySelectorAll("#komiStepper .komi-step-btn").forEach((b) => b.setAttribute("disabled", "true"));
+		document.getElementById("komiselect").value = preset.komi;
+		document.getElementById("komiselect").setAttribute("disabled", "true");
 		document.getElementById("gametype").value = preset.type;
 		document.getElementById("gametype").setAttribute("disabled", "true");
 		document.getElementById("timeselect").value = preset.time;
@@ -660,14 +601,14 @@ function resetGameSettings() {
 	document.getElementById("boardsize").value = "5";
 	document.getElementById("piececount").value = "21";
 	document.getElementById("capcount").value = "1";
-	setBalancingValues(false, 0, "swap");
-	document.getElementById("komiValue").textContent = "2";
+	document.getElementById("komiselect").value = "0";
 	document.getElementById("gametype").value = "0";
 	document.getElementById("timeselect").value = "600";
 	document.getElementById("incselect").value = "20";
 	document.getElementById("triggerMove").value = "";
 	document.getElementById("timeAmount").value = "";
 	document.getElementById("colorselect").value = "A";
+	document.getElementById("openingselect").value = "swap";
 	document.getElementById("opname").value = "";
 	document.getElementById("preset").value = "none";
 }
@@ -682,12 +623,13 @@ function loadGameSettings() {
 	document.getElementById("boardsize").value = storedValues.size;
 	document.getElementById("piececount").value = storedValues.pieces;
 	document.getElementById("capcount").value = storedValues.capstones;
-	setBalancingValues(false, storedValues.komi, storedValues.opening || "swap");
+	document.getElementById("komiselect").value = storedValues.komi;
 	document.getElementById("gametype").value = storedValues.type;
 	document.getElementById("timeselect").value = storedValues.time;
 	document.getElementById("incselect").value = storedValues.increment;
 	document.getElementById("triggerMove").value = storedValues.trigger_move;
 	document.getElementById("colorselect").value = storedValues.color || "A";
+	document.getElementById("openingselect").value = storedValues.opening || "swap";
 }
 
 function resetToLoginState() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -496,11 +496,70 @@ function fastforward() {
 function resetFormFieldAttributes() {
 	const form = document.getElementById("create-game-form");
 	// remove the required attribute from all elements
-	const allFields = form.querySelectorAll("input, select");
+	const allFields = form.querySelectorAll("input, select, .komi-step-btn");
 	allFields.forEach((field) => {
 		field.removeAttribute("required");
 		field.removeAttribute("disabled");
 	});
+}
+
+// --- Balancing Mechanism control (None / Komi / Double Black Stack) ---
+// A single selector that maps onto the underlying komi + opening values.
+// komi is stored in half-points (komi / 2 = the points shown to the user).
+function balancingIds(isScratch) {
+	return isScratch
+		? { select: "scratchBalancingSelect", stepper: "scratchKomiStepper", value: "scratchKomiValue" }
+		: { select: "balancingselect", stepper: "komiStepper", value: "komiValue" };
+}
+
+function formatKomiPoints(points) {
+	return Number.isInteger(points) ? String(points) : points.toFixed(1);
+}
+
+// Show the komi stepper only when "Komi" is the selected mechanism.
+function updateBalancingMechanism(isScratch) {
+	const ids = balancingIds(isScratch);
+	const mech = document.getElementById(ids.select).value;
+	document.getElementById(ids.stepper).style.display = mech === "komi" ? "flex" : "none";
+}
+
+// Adjust the komi value by +/- 0.5, clamped to a 0.5 minimum.
+function stepKomi(isScratch, delta) {
+	const ids = balancingIds(isScratch);
+	const el = document.getElementById(ids.value);
+	let points = parseFloat(el.textContent) || 2;
+	points = Math.max(0.5, Math.round((points + delta) * 2) / 2);
+	el.textContent = formatKomiPoints(points);
+}
+
+// Read the control as { komi, opening } in the underlying wire representation.
+function getBalancingValues(isScratch) {
+	const ids = balancingIds(isScratch);
+	const mech = document.getElementById(ids.select).value;
+	if (mech === "komi") {
+		const points = parseFloat(document.getElementById(ids.value).textContent) || 2;
+		return { komi: Math.round(points * 2), opening: "swap" };
+	}
+	if (mech === "double black stack") {
+		return { komi: 0, opening: "double black stack" };
+	}
+	return { komi: 0, opening: "swap" };
+}
+
+// Set the control from underlying komi + opening values (reverse of getBalancingValues).
+function setBalancingValues(isScratch, komi, opening) {
+	const ids = balancingIds(isScratch);
+	const sel = document.getElementById(ids.select);
+	komi = Number(komi) || 0;
+	if (opening === "double black stack") {
+		sel.value = "double black stack";
+	} else if (komi > 0) {
+		sel.value = "komi";
+		document.getElementById(ids.value).textContent = formatKomiPoints(komi / 2);
+	} else {
+		sel.value = "none";
+	}
+	updateBalancingMechanism(isScratch);
 }
 
 function changePreset(event) {
@@ -520,13 +579,12 @@ function changePreset(event) {
 		document.getElementById("boardsize").value = storedValues.size;
 		document.getElementById("piececount").value = storedValues.pieces;
 		document.getElementById("capcount").value = storedValues.capstones;
-		document.getElementById("komiselect").value = storedValues.komi;
+		setBalancingValues(false, storedValues.komi, storedValues.opening || "swap");
 		document.getElementById("gametype").value = storedValues.type;
 		document.getElementById("timeselect").value = storedValues.time;
 		document.getElementById("incselect").value = storedValues.increment;
 		document.getElementById("triggerMove").value = storedValues.trigger_move;
 		document.getElementById("timeAmount").value = storedValues.time_amount;
-		document.getElementById("openingselect").value = storedValues.opening || "swap";
 		return;
 	} else if (preset) {
 		// store the current values if user changes back to the noen preset
@@ -534,13 +592,13 @@ function changePreset(event) {
 			size: document.getElementById("boardsize").value,
 			pieces: document.getElementById("piececount").value,
 			capstones: document.getElementById("capcount").value,
-			komi: document.getElementById("komiselect").value,
+			komi: getBalancingValues(false).komi,
 			type: document.getElementById("gametype").value,
 			time: document.getElementById("timeselect").value,
 			increment: document.getElementById("incselect").value,
 			trigger_move: document.getElementById("triggerMove").value,
 			time_amount: document.getElementById("timeAmount").value,
-			opening: document.getElementById("openingselect").value,
+			opening: getBalancingValues(false).opening,
 		};
 		localStorage.setItem(
 			"current-game-settings",
@@ -552,8 +610,9 @@ function changePreset(event) {
 		document.getElementById("piececount").setAttribute("disabled", "true");
 		document.getElementById("capcount").value = preset.capstones;
 		document.getElementById("capcount").setAttribute("disabled", "true");
-		document.getElementById("komiselect").value = preset.komi;
-		document.getElementById("komiselect").setAttribute("disabled", "true");
+		setBalancingValues(false, preset.komi, "swap");
+		document.getElementById("balancingselect").setAttribute("disabled", "true");
+		document.querySelectorAll("#komiStepper .komi-step-btn").forEach((b) => b.setAttribute("disabled", "true"));
 		document.getElementById("gametype").value = preset.type;
 		document.getElementById("gametype").setAttribute("disabled", "true");
 		document.getElementById("timeselect").value = preset.time;
@@ -601,14 +660,14 @@ function resetGameSettings() {
 	document.getElementById("boardsize").value = "5";
 	document.getElementById("piececount").value = "21";
 	document.getElementById("capcount").value = "1";
-	document.getElementById("komiselect").value = "0";
+	setBalancingValues(false, 0, "swap");
+	document.getElementById("komiValue").textContent = "2";
 	document.getElementById("gametype").value = "0";
 	document.getElementById("timeselect").value = "600";
 	document.getElementById("incselect").value = "20";
 	document.getElementById("triggerMove").value = "";
 	document.getElementById("timeAmount").value = "";
 	document.getElementById("colorselect").value = "A";
-	document.getElementById("openingselect").value = "swap";
 	document.getElementById("opname").value = "";
 	document.getElementById("preset").value = "none";
 }
@@ -623,13 +682,12 @@ function loadGameSettings() {
 	document.getElementById("boardsize").value = storedValues.size;
 	document.getElementById("piececount").value = storedValues.pieces;
 	document.getElementById("capcount").value = storedValues.capstones;
-	document.getElementById("komiselect").value = storedValues.komi;
+	setBalancingValues(false, storedValues.komi, storedValues.opening || "swap");
 	document.getElementById("gametype").value = storedValues.type;
 	document.getElementById("timeselect").value = storedValues.time;
 	document.getElementById("incselect").value = storedValues.increment;
 	document.getElementById("triggerMove").value = storedValues.trigger_move;
 	document.getElementById("colorselect").value = storedValues.color || "A";
-	document.getElementById("openingselect").value = storedValues.opening || "swap";
 }
 
 function resetToLoginState() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -390,6 +390,10 @@ function getNotation(id) {
 	res += getHeader("Komi", gameData.komi / 2);
 	res += getHeader("Flats", gameData.pieces);
 	res += getHeader("Caps", gameData.capstones);
+	// Opening variant (PTN Ninja tag). Omitted for the default "swap".
+	if (gameData.opening && gameData.opening !== "swap") {
+		res += getHeader("Opening", gameData.opening);
+	}
 	res += getHeader("Result", gameData.result);
 	res += "\r\n";
 
@@ -503,6 +507,7 @@ function changePreset(event) {
 		document.getElementById("incselect").value = storedValues.increment;
 		document.getElementById("triggerMove").value = storedValues.trigger_move;
 		document.getElementById("timeAmount").value = storedValues.time_amount;
+		document.getElementById("openingselect").value = storedValues.opening || "swap";
 		return;
 	} else if (preset) {
 		// store the current values if user changes back to the noen preset
@@ -516,6 +521,7 @@ function changePreset(event) {
 			increment: document.getElementById("incselect").value,
 			trigger_move: document.getElementById("triggerMove").value,
 			time_amount: document.getElementById("timeAmount").value,
+			opening: document.getElementById("openingselect").value,
 		};
 		localStorage.setItem(
 			"current-game-settings",
@@ -583,6 +589,7 @@ function resetGameSettings() {
 	document.getElementById("triggerMove").value = "";
 	document.getElementById("timeAmount").value = "";
 	document.getElementById("colorselect").value = "A";
+	document.getElementById("openingselect").value = "swap";
 	document.getElementById("opname").value = "";
 	document.getElementById("preset").value = "none";
 }
@@ -603,6 +610,7 @@ function loadGameSettings() {
 	document.getElementById("incselect").value = storedValues.increment;
 	document.getElementById("triggerMove").value = storedValues.trigger_move;
 	document.getElementById("colorselect").value = storedValues.color || "A";
+	document.getElementById("openingselect").value = storedValues.opening || "swap";
 }
 
 function resetToLoginState() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,9 +1,19 @@
-// Parses an #incselect value like "20" or "1*n" into { increment, increment_scales }.
+// View<->model bridge for the #incselect dropdown. The dropdown packs two server
+// fields (a numeric increment + a boolean increment_scales) into one option token
+// like "20" (fixed) or "1*n" (scales with move number). Increment is treated as
+// numeric DATA everywhere; the string token only exists as the <select>.value.
+
+// Decode an #incselect token into { increment: Number, increment_scales: Boolean }.
 function parseIncrementValue(value) {
 	const str = String(value ?? "0");
 	const scales = str.endsWith("*n");
 	const increment = parseInt(scales ? str.slice(0, -2) : str, 10) || 0;
 	return { increment, increment_scales: scales };
+}
+
+// Encode { increment, increment_scales } back into an #incselect token ("20" / "1*n").
+function incrementTokenForSelect(increment, increment_scales) {
+	return increment_scales ? `${increment}*n` : String(increment);
 }
 
 const gamePresets = {
@@ -14,7 +24,8 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 900,
-		increment: "10",
+		increment: 10,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "",
 		required_fields: ["opname"],
@@ -26,7 +37,8 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 900,
-		increment: "10",
+		increment: 10,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "",
 		required_fields: ["opname"],
@@ -38,7 +50,8 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 900, // seconds
-		increment: "10",
+		increment: 10,
+		increment_scales: false,
 		trigger_move: 35,
 		time_amount: 300, // seconds
 		required_fields: ["opname"],
@@ -50,7 +63,8 @@ const gamePresets = {
 		pieces: 40,
 		capstones: 2,
 		time: 1200, // seconds
-		increment: "15",
+		increment: 15,
+		increment_scales: false,
 		trigger_move: 40,
 		time_amount: 600, // seconds
 		required_fields: ["opname"],
@@ -62,7 +76,8 @@ const gamePresets = {
 		pieces: 40,
 		capstones: 2,
 		time: 300, // seconds
-		increment: "5",
+		increment: 5,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -74,7 +89,8 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 1200, // seconds
-		increment: "15",
+		increment: 15,
+		increment_scales: false,
 		trigger_move: "35",
 		time_amount: "600", // seconds
 		required_fields: ["opname"],
@@ -86,7 +102,8 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 900, // seconds
-		increment: "15",
+		increment: 15,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -98,7 +115,8 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 600, // seconds
-		increment: "15",
+		increment: 15,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -110,7 +128,8 @@ const gamePresets = {
 		pieces: 30,
 		capstones: 1,
 		time: 180, // seconds
-		increment: "5",
+		increment: 5,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],
@@ -539,7 +558,7 @@ function changePreset(event) {
 		document.getElementById("gametype").setAttribute("disabled", "true");
 		document.getElementById("timeselect").value = preset.time;
 		document.getElementById("timeselect").setAttribute("disabled", "true");
-		document.getElementById("incselect").value = preset.increment;
+		document.getElementById("incselect").value = incrementTokenForSelect(preset.increment, preset.increment_scales);
 		document.getElementById("incselect").setAttribute("disabled", "true");
 		document.getElementById("triggerMove").value = preset.trigger_move;
 		document.getElementById("triggerMove").setAttribute("disabled", "true");
@@ -784,6 +803,8 @@ $(document).ready(function () {
 		showElement("play-button");
 	}
 	loadGameSettings();
+	// opt-in Bootstrap popovers (e.g. the increment-scaling help in the create-game form)
+	$('[data-toggle="popover"]').popover();
 	// get current game settings
 	fetchEvents();
 	init();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -51,6 +51,7 @@ const gamePresets = {
 		capstones: 1,
 		time: 600, // seconds
 		increment: 20,
+		increment_scales: false,
 		trigger_move: "",
 		time_amount: "", // seconds
 		required_fields: ["opname"],

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -1594,13 +1594,13 @@ var server = {
 			time: document.getElementById("timeselect").value,
 			increment: document.getElementById("incselect").value,
 			color: document.getElementById("colorselect").value,
-			komi: getBalancingValues(false).komi,
+			komi: document.getElementById("komiselect").value,
 			pieces: document.getElementById("piececount").value,
 			capstones: document.getElementById("capcount").value,
 			type: document.getElementById("gametype").value,
 			trigger_move: document.getElementById("triggerMove").value,
 			time_amount: document.getElementById("timeAmount").value,
-			opening: getBalancingValues(false).opening
+			opening: document.getElementById("openingselect").value
 		};
 		// save the current game seetings to local storage
 		localStorage.setItem("current-game-settings", JSON.stringify(game));

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -1172,7 +1172,7 @@ var server = {
 		const hasExtra = (Number(game.triggerMove) > 0 && Number(game.timeAmount) > 0);
 		const extraText = "+" + game.timeAmount + "m @" + game.triggerMove;
 		// Time: base time + increment (playtak-games style); extra time on a 2nd line
-		$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", game.incrementScales ? "Time control and increment (increment scales with move number)" : "Time control and increment").appendTo(row);
+		$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", game.incrementScales ? "Time control and increment (n = the current move number)" : "Time control and increment").appendTo(row);
 		// Rules: consolidated komi / pieces / opening (see the seek list for details).
 		const rulesLines = [];
 		const rulesTips = [];
@@ -1398,7 +1398,7 @@ var server = {
 			const hasExtra = (Number(seek.trigger_move) > 0 && Number(seek.time_amount) > 0);
 			const extraText = "+" + seek.time_amount + "m @" + seek.trigger_move;
 			// Time: base time + increment (playtak-games style); extra time on a 2nd line
-			$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", seek.increment_scales ? "Time control and increment (increment scales with move number)" : "Time control and increment").appendTo(row);
+			$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", seek.increment_scales ? "Time control and increment (n = the current move number)" : "Time control and increment").appendTo(row);
 			// Rules: consolidated komi / pieces / opening. Only non-default values are
 			// shown, each on its own line. The opening name appears without an "Opening:"
 			// label (kept compact via a smaller, wrappable font); the per-row tooltip

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -688,7 +688,9 @@ var server = {
 				unrated: spl[12] == 1,
 				tournament: spl[13] == 1,
 				triggerMove: spl[14],
-				timeAmount: parseInt(spl[15]) / 60
+				timeAmount: parseInt(spl[15]) / 60,
+				// protocol 4 appends the opening code after timeAmount
+				opening: openingNameFromCode(+(spl[16] || 0))
 			};
 			this.gameslist.push(game);
 			this.addGameToWatchList(game);
@@ -1134,15 +1136,15 @@ var server = {
 		let gameType = "";
 		let gameTypeText = "";
 		if(!game.unrated && !game.tournament){
-			gameType = "N";
+			gameType = "Normal";
 			gameTypeText = "Normal game";
 		}
 		else if(game.unrated && !game.tournament){
-			gameType = "U";
+			gameType = "Unrated";
 			gameTypeText = "Unrated game";
 		}
 		else if(!game.unrated && game.tournament){
-			gameType = "T";
+			gameType = "Tournament";
 			gameTypeText = "Tournament game";
 		}
 		const players = document.createElement("button");
@@ -1159,12 +1161,39 @@ var server = {
 		$('<td/>').append(actionButton).attr("data-toggle", "tooltip").attr("title", "Watch game").click(game,function(ev){server.observegame(ev.data);}).appendTo(row);
 		$('<td/>').append(players).click(game,function(ev){server.observegame(ev.data);}).appendTo(row);
 		// game details
-		$('<td/>').append("<span class='badge'>"+game.size+"x"+game.size+"</span>").addClass("right").appendTo(row);
-		$('<td/>').append(minuteseconds(game.time) + ' +'+minuteseconds(game.increment) + (game.incrementScales ? '&times;n' : '')).addClass("right time-rule").attr("data-toggle", "tooltip").attr("title", game.incrementScales ? "Time control and increment (increment scales with move number)" : "Time control and increment").appendTo(row);
-		$('<td/>').append('+'+Math.floor(game.komi/2)+"."+(game.komi&1?"5":"0")).addClass("right komi-rule").attr("data-toggle", "tooltip").attr("title","Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined").appendTo(row);
-		$('<td/>').append(game.pieces+"/"+game.capstones).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title","Stone count - The number of stones/capstones that each player has in this game").appendTo(row);
-		$('<td/>').append(gameType).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", gameTypeText).appendTo(row);
-		$("<td/>").append(game.triggerMove + "/+" + parseInt(game.timeAmount)).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", "Trigger move and extra time to add in minutes").appendTo(row);
+		$('<td/>').append("<span class='badge'>"+game.size+"x"+game.size+"</span>").appendTo(row);
+		// shared rule values, reused by the Rules cell and the mobile detail menu
+		const stdPieces = [0,0,0,10,15,21,30,40,50][game.size];
+		const stdCaps = [0,0,0,0,0,1,1,2,2][game.size];
+		const piecesVary = (game.pieces !== stdPieces || game.capstones !== stdCaps);
+		const komiText = Math.floor(game.komi/2) + (game.komi&1 ? ".5" : "");
+		const gameOpeningFull = game.opening === "double black stack" ? "Double Black Stack" : "Single Swap";
+		const timeText = (game.time/60) + "m +" + game.increment + "s" + (game.incrementScales ? "&times;n" : "") + " inc";
+		const hasExtra = (Number(game.triggerMove) > 0 && Number(game.timeAmount) > 0);
+		const extraText = "+" + game.timeAmount + "m @" + game.triggerMove;
+		// Time: base time + increment (playtak-games style); extra time on a 2nd line
+		$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", game.incrementScales ? "Time control and increment (increment scales with move number)" : "Time control and increment").appendTo(row);
+		// Rules: consolidated komi / pieces / opening (see the seek list for details).
+		const rulesLines = [];
+		const rulesTips = [];
+		if(game.komi > 0){
+			rulesLines.push("Komi: " + komiText);
+			rulesTips.push("Komi: if the game ends without a road, Black adds this to their flat count.");
+		}
+		if(piecesVary){
+			rulesLines.push("Pieces: " + game.pieces + "/" + game.capstones);
+			rulesTips.push("Pieces: the number of stones/capstones each player has.");
+		}
+		if(game.opening && game.opening !== "swap"){
+			rulesLines.push(gameOpeningFull);
+			rulesTips.push("Double Black Stack: White opens by placing a stack of two black flats.");
+		}
+		const rulesCell = $('<td/>').append(rulesLines.join("<br>")).addClass("rules-col rules-rule");
+		if(rulesTips.length){
+			rulesCell.attr("data-toggle", "tooltip").attr("data-html", "true").attr("title", rulesTips.join("<br>"));
+		}
+		rulesCell.appendTo(row);
+		$('<td/>').append(gameType).addClass("hide-sm").attr("data-toggle", "tooltip").attr("title", gameTypeText).appendTo(row);
 
 		const dropdownButton = document.createElement("button");
 		dropdownButton.className = "btn btn-transparent dropdown-toggle";
@@ -1180,50 +1209,26 @@ var server = {
 		dropdownMenu.id = "game-" + game.id + "-menu";
 		// aria-label by
 		dropdownMenu.setAttribute("aria-labelledby", "game-" + game.id);
-		// add the drop down items
-		// time
-		const timeItem = document.createElement("span");
-		timeItem.className = "dropdown-item time-rule-menu";
-		timeItem.style.display = "none";
-		timeItem.innerHTML = `<strong>Time Control:</strong> ${minuteseconds(game.time)}`;
-		dropdownMenu.appendChild(timeItem);
-		// increment
-		const incrementItem = document.createElement("span");
-		incrementItem.className = "dropdown-item time-rule-menu";
-		incrementItem.style.display = "none";
-		incrementItem.innerHTML = `<strong>Increment:</strong> +${minuteseconds(game.increment)}${game.incrementScales ? ' &times; move number' : ''}`;
-		dropdownMenu.appendChild(incrementItem);
-		// komi
-		const komiItem = document.createElement("span");
-		komiItem.className = "dropdown-item komi-rule-menu";
-		komiItem.style.display = "none";
-		komiItem.innerHTML = `<strong>Komi:</strong> +${Math.floor(game.komi/2)}.${(game.komi&1)?"5":"0"}`;
-		dropdownMenu.appendChild(komiItem);
-		// pieces
-		const piecesItem = document.createElement("span");
-		piecesItem.className = "dropdown-item";
-		piecesItem.innerHTML = `<strong>Pieces:</strong> ${game.pieces}/${game.capstones}`;
-		dropdownMenu.appendChild(piecesItem);
-		// capstones
-		const capstonesItem = document.createElement("span");
-		capstonesItem.className = "dropdown-item";
-		capstonesItem.innerHTML = `<strong>Capstones:</strong> ${game.capstones}`;
-		dropdownMenu.appendChild(capstonesItem);
-		// game type
-		const gameTypeItem = document.createElement("span");
-		gameTypeItem.className = "dropdown-item";
-		gameTypeItem.innerHTML = `<strong>Game Type:</strong> ${gameTypeText}`;
-		dropdownMenu.appendChild(gameTypeItem);
-		// trigger move
-		const triggerMoveItem = document.createElement("span");
-		triggerMoveItem.className = "dropdown-item";
-		triggerMoveItem.innerHTML = `<strong>Trigger Move:</strong> ${game.triggerMove}`;
-		dropdownMenu.appendChild(triggerMoveItem);
-		// extra time
-		const extraTimeItem = document.createElement("span");
-		extraTimeItem.className = "dropdown-item";
-		extraTimeItem.innerHTML = `<strong>Extra Time:</strong> +${game.timeAmount} minutes`;
-		dropdownMenu.appendChild(extraTimeItem);
+		// Detail menu items, revealed as their column drops out at narrower widths.
+		const addMenuItem = function(html, cls){
+			const item = document.createElement("span");
+			item.className = "dropdown-item" + (cls ? " " + cls : "");
+			if(cls){ item.style.display = "none"; }
+			item.innerHTML = html;
+			dropdownMenu.appendChild(item);
+		};
+		// Time control mirrors the Time column; extra time follows it when set.
+		addMenuItem(`<strong>Time Control:</strong> ${timeText}`, "time-rule-menu");
+		if(hasExtra){ addMenuItem(`<strong>Extra Time:</strong> ${extraText}`, "time-rule-menu"); }
+		// Rules detail, shown only when the Rules column is hidden.
+		if(game.komi > 0){ addMenuItem(`<strong>Komi:</strong> ${komiText}`, "rules-rule-menu"); }
+		if(piecesVary){
+			addMenuItem(`<strong>Pieces:</strong> ${game.pieces}/${game.capstones}`, "rules-rule-menu");
+			addMenuItem(`<strong>Capstones:</strong> ${game.capstones}`, "rules-rule-menu");
+		}
+		if(game.opening && game.opening !== "swap"){ addMenuItem(`<strong>Opening:</strong> ${gameOpeningFull}`, "rules-rule-menu"); }
+		// Game type, shown when the Type column is hidden.
+		addMenuItem(`<strong>Game Type:</strong> ${gameTypeText}`);
 		// create  dropdown div with dropdown class
 		const dropdownDiv = document.createElement("div");
 		dropdownDiv.className = "dropdown";
@@ -1344,21 +1349,20 @@ var server = {
 			let gameType = "";
 			let gameTypeText = "";
 			if(!seek.unrated && !seek.tournament){
-				gameType = "N";
+				gameType = "Normal";
 				gameTypeText = "Normal game";
 			}
 			else if(seek.unrated && !seek.tournament){
-				gameType = "U";
+				gameType = "Unrated";
 				gameTypeText = "Unrated game";
 			}
 			else if(!seek.unrated && seek.tournament){
-				gameType = "T";
+				gameType = "Tournament";
 				gameTypeText = "Tournament game";
 			}
 
-			// Opening: abbreviation (SS/DBS) for the desktop column, full text for the mobile menu.
+			// Opening: full label used in the Rules column and the mobile detail menu.
 			const openingFull = seek.opening === "double black stack" ? "Double Black Stack" : "Single Swap";
-			const openingAbbr = seek.opening === "double black stack" ? "DBS" : "SS";
 
 			const challengePlayerButton = document.createElement("button");
 			challengePlayerButton.className = "btn btn-transparent seek-button";
@@ -1383,13 +1387,42 @@ var server = {
 			}).attr("data-toggle", "tooltip").attr("title", mySeek ? "Remove seek" : "Challenge " + seek.player).appendTo(row);
 			$('<td/>').append(ratingdecoration + " " + (seek.player_rating || "")).addClass("right").attr("data-toggle", "tooltip").attr("title",ratingtext).appendTo(row);
 			// game details
-			$('<td/>').append(sizespan).addClass("right").appendTo(row);
-			$('<td/>').append(minuteseconds(seek.time) + ' +'+minuteseconds(seek.increment) + (seek.increment_scales ? '&times;n' : '')).addClass("right time-rule").attr("data-toggle", "tooltip").attr("title", seek.increment_scales ? "Time control and increment (increment scales with move number)" : "Time control and increment").appendTo(row);
-			$('<td/>').append((Math.floor(seek.komi/2)||(seek.komi&1?"":"0"))+(seek.komi&1?"&frac12;":"")).addClass("right komi-rule").attr("data-toggle", "tooltip").attr("title","Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined").appendTo(row);
-			$('<td/>').append(seek.pieces+"/"+seek.capstones).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title","Stone count - The number of stones/capstones that each player has in this game").appendTo(row);
-			$('<td/>').append(gameType).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title",gameTypeText).appendTo(row);
-			$('<td/>').append(seek.trigger_move+"/+"+seek.time_amount).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", "Extra Time - The trigger move the player must reach and the time to add to the clock").appendTo(row);
-			$('<td/>').append(openingAbbr).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title","Opening - " + openingFull).appendTo(row);
+			$('<td/>').append(sizespan).appendTo(row);
+			// shared rule values, reused by the Rules cell and the mobile detail menu
+			const seekSize = parseInt(seek.size);
+			const stdPieces = [0,0,0,10,15,21,30,40,50][seekSize];
+			const stdCaps = [0,0,0,0,0,1,1,2,2][seekSize];
+			const piecesVary = (seek.pieces !== stdPieces || seek.capstones !== stdCaps);
+			const komiText = Math.floor(seek.komi/2) + (seek.komi&1 ? ".5" : "");
+			const timeText = (seek.time/60) + "m +" + seek.increment + "s" + (seek.increment_scales ? "&times;n" : "") + " inc";
+			const hasExtra = (Number(seek.trigger_move) > 0 && Number(seek.time_amount) > 0);
+			const extraText = "+" + seek.time_amount + "m @" + seek.trigger_move;
+			// Time: base time + increment (playtak-games style); extra time on a 2nd line
+			$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", seek.increment_scales ? "Time control and increment (increment scales with move number)" : "Time control and increment").appendTo(row);
+			// Rules: consolidated komi / pieces / opening. Only non-default values are
+			// shown, each on its own line. The opening name appears without an "Opening:"
+			// label (kept compact via a smaller, wrappable font); the per-row tooltip
+			// explains only the rules that actually apply to this seek.
+			const rulesLines = [];
+			const rulesTips = [];
+			if(seek.komi > 0){
+				rulesLines.push("Komi: " + komiText);
+				rulesTips.push("Komi: if the game ends without a road, Black adds this to their flat count.");
+			}
+			if(piecesVary){
+				rulesLines.push("Pieces: " + seek.pieces + "/" + seek.capstones);
+				rulesTips.push("Pieces: the number of stones/capstones each player has.");
+			}
+			if(seek.opening !== "swap"){
+				rulesLines.push(openingFull);
+				rulesTips.push("Double Black Stack: White opens by placing a stack of two black flats.");
+			}
+			const rulesCell = $('<td/>').append(rulesLines.join("<br>")).addClass("rules-col rules-rule");
+			if(rulesTips.length){
+				rulesCell.attr("data-toggle", "tooltip").attr("data-html", "true").attr("title", rulesTips.join("<br>"));
+			}
+			rulesCell.appendTo(row);
+			$('<td/>').append(gameType).addClass("hide-sm").attr("data-toggle", "tooltip").attr("title",gameTypeText).appendTo(row);
 			// add the same deetails to a dropdown on mobile
 			const dropdownButton = document.createElement("button");
 			dropdownButton.className = "btn btn-transparent dropdown-toggle";
@@ -1405,58 +1438,26 @@ var server = {
 			dropdownMenu.id = "seek-" + seek.id + "-menu";
 			// aria-label by
 			dropdownMenu.setAttribute("aria-labelledby", "seek-" + seek.id);
-			// add the drop down items
-			// time
-			const timeItem = document.createElement("span");
-			timeItem.className = "dropdown-item time-rule-menu";
-			// set default display none
-			timeItem.style.display = "none";
-			timeItem.innerHTML = `<strong>Time Control:</strong> ${minuteseconds(seek.time)}`;
-			dropdownMenu.appendChild(timeItem);
-			// increment
-			const incrementItem = document.createElement("span");
-			incrementItem.className = "dropdown-item time-rule-menu";
-			// set default display none
-			incrementItem.style.display = "none";
-			incrementItem.innerHTML = `<strong>Increment:</strong> +${minuteseconds(seek.increment)}${seek.increment_scales ? ' &times; move number' : ''}`;
-			dropdownMenu.appendChild(incrementItem);
-			// komi
-			const komiItem = document.createElement("span");
-			komiItem.className = "dropdown-item komi-rule-menu";
-			// set default display none
-			komiItem.style.display = "none";
-			komiItem.innerHTML = `<strong>Komi:</strong> +${Math.floor(seek.komi/2)}.${(seek.komi&1)?"5":"0"}`;
-			dropdownMenu.appendChild(komiItem);
-			// pieces
-			const piecesItem = document.createElement("span");
-			piecesItem.className = "dropdown-item";
-			piecesItem.innerHTML = `<strong>Pieces:</strong> ${seek.pieces}/${seek.capstones}`;
-			dropdownMenu.appendChild(piecesItem);
-			// capstones
-			const capstonesItem = document.createElement("span");
-			capstonesItem.className = "dropdown-item";
-			capstonesItem.innerHTML = `<strong>Capstones:</strong> ${seek.capstones}`;
-			dropdownMenu.appendChild(capstonesItem);
-			// game type
-			const gameTypeItem = document.createElement("span");
-			gameTypeItem.className = "dropdown-item";
-			gameTypeItem.innerHTML = `<strong>Game Type:</strong> ${gameTypeText}`;
-			dropdownMenu.appendChild(gameTypeItem);
-			// opening
-			const openingItem = document.createElement("span");
-			openingItem.className = "dropdown-item";
-			openingItem.innerHTML = `<strong>Opening:</strong> ${openingFull}`;
-			dropdownMenu.appendChild(openingItem);
-			// trigger move
-			const triggerMoveItem = document.createElement("span");
-			triggerMoveItem.className = "dropdown-item";
-			triggerMoveItem.innerHTML = `<strong>Trigger Move:</strong> ${seek.trigger_move}`;
-			dropdownMenu.appendChild(triggerMoveItem);
-			// extra time
-			const extraTimeItem = document.createElement("span");
-			extraTimeItem.className = "dropdown-item";
-			extraTimeItem.innerHTML = `<strong>Extra Time:</strong> +${seek.time_amount} minutes`;
-			dropdownMenu.appendChild(extraTimeItem);
+			// Detail menu items, revealed as their column drops out at narrower widths.
+			const addMenuItem = function(html, cls){
+				const item = document.createElement("span");
+				item.className = "dropdown-item" + (cls ? " " + cls : "");
+				if(cls){ item.style.display = "none"; }
+				item.innerHTML = html;
+				dropdownMenu.appendChild(item);
+			};
+			// Time control mirrors the Time column; extra time follows it when set.
+			addMenuItem(`<strong>Time Control:</strong> ${timeText}`, "time-rule-menu");
+			if(hasExtra){ addMenuItem(`<strong>Extra Time:</strong> ${extraText}`, "time-rule-menu"); }
+			// Rules detail, shown only when the Rules column is hidden.
+			if(seek.komi > 0){ addMenuItem(`<strong>Komi:</strong> ${komiText}`, "rules-rule-menu"); }
+			if(piecesVary){
+				addMenuItem(`<strong>Pieces:</strong> ${seek.pieces}/${seek.capstones}`, "rules-rule-menu");
+				addMenuItem(`<strong>Capstones:</strong> ${seek.capstones}`, "rules-rule-menu");
+			}
+			if(seek.opening !== "swap"){ addMenuItem(`<strong>Opening:</strong> ${openingFull}`, "rules-rule-menu"); }
+			// Game type, shown when the Type column is hidden.
+			addMenuItem(`<strong>Game Type:</strong> ${gameTypeText}`);
 			// create  dropdown div with dropdown class
 			const dropdownDiv = document.createElement("div");
 			dropdownDiv.className = "dropdown";

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -1594,13 +1594,13 @@ var server = {
 			time: document.getElementById("timeselect").value,
 			increment: document.getElementById("incselect").value,
 			color: document.getElementById("colorselect").value,
-			komi: document.getElementById("komiselect").value,
+			komi: getBalancingValues(false).komi,
 			pieces: document.getElementById("piececount").value,
 			capstones: document.getElementById("capcount").value,
 			type: document.getElementById("gametype").value,
 			trigger_move: document.getElementById("triggerMove").value,
 			time_amount: document.getElementById("timeAmount").value,
-			opening: document.getElementById("openingselect").value
+			opening: getBalancingValues(false).opening
 		};
 		// save the current game seetings to local storage
 		localStorage.setItem("current-game-settings", JSON.stringify(game));

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -193,8 +193,10 @@ var server = {
 		if(moveData.type === 'P'){
 			// file,rank,caporwall
 			if(is2DBoard){
-				appendPly(`${spl[3] ? spl[3] === 'W' ? 'S': spl[3] : ''}${spl[2]}`);
-				notate(`${spl[3] ? spl[3] === 'W' ? 'S': spl[3] : ''}${spl[2].toLowerCase()}`);
+				// Double Black Stack: white's first ply is written "2a1"
+				const dbsPrefix = (gameData.opening === 'double black stack' && gameData.move_count === 0) ? '2' : '';
+				appendPly(`${dbsPrefix}${spl[3] ? spl[3] === 'W' ? 'S': spl[3] : ''}${spl[2]}`);
+				notate(`${dbsPrefix}${spl[3] ? spl[3] === 'W' ? 'S': spl[3] : ''}${spl[2].toLowerCase()}`);
 				incrementMoveCounter();
 				storeNotation();
 				if(!loadingGameHistory){
@@ -367,7 +369,7 @@ var server = {
 	},
 	sendClient: function(){
 		server.send("Client TakWeb-22.04.12");
-		server.send("Protocol 3");
+		server.send("Protocol 4");
 	},
 	login: function(){
 		this.anotherlogin=false;
@@ -521,9 +523,11 @@ var server = {
 			gameData.triggerMove = +spl[16];
 			gameData.timeAmount = +spl[17];
 			gameData.bot = +spl[18];
+			// protocol 4 appends the opening code after the bot flag
+			gameData.opening = openingNameFromCode(+(spl[19] || 0));
 			gameData.is_scratch = false;
 			gameData.observing = false;
-			storeNotation(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]`);
+			storeNotation(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]${gameData.opening !== 'swap' ? `[Opening "${gameData.opening}"]` : ''}`);
 			initBoard();
 			loadingGameHistory = true;
 			// store the game object in local storage
@@ -584,7 +588,7 @@ var server = {
 			// Forward player names + initial clock values to the PTN Ninja iframe.
 			// Live ticking is enabled once the first Time message arrives.
 			if(is2DBoard){
-				set2DBoard(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"][Player1 "${p1}"][Player2 "${p2}"]`);
+				set2DBoard(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]${gameData.opening !== 'swap' ? `[Opening "${gameData.opening}"]` : ''}[Player1 "${p1}"][Player2 "${p2}"]`);
 				set2DTimerLive(false);
 				set2DGameTime({
 					time1: time * 1000,
@@ -636,12 +640,14 @@ var server = {
 			gameData.tournament = +spl[12];
 			gameData.triggerMove = +spl[13];
 			gameData.timeAmount = +spl[14];
+			// protocol 4 appends the opening code after timeAmount
+			gameData.opening = openingNameFromCode(+(spl[15] || 0));
 			gameData.bot = 1;
 			gameData.observing = true;
 			gameData.is_scratch = false;
 			gameData.chatRoom = "room-" + [p1, p2].sort().join("-");
 			chathandler.insertGameSeparator(gameData.chatRoom, gameData.id);
-			storeNotation(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]`);
+			storeNotation(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]${gameData.opening !== 'swap' ? `[Opening "${gameData.opening}"]` : ''}`);
 			initBoard();
 			loadingGameHistory = true;
 			if(is2DBoard){
@@ -656,7 +662,7 @@ var server = {
 
 			// Forward player names + initial clock values to the PTN Ninja iframe.
 			if(is2DBoard){
-				set2DBoard(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"][Player1 "${p1}"][Player2 "${p2}"]`);
+				set2DBoard(`[Size "${gameData.size}"][Komi "${gameData.komi/2}"][Flats "${gameData.pieces}"][Caps "${gameData.capstones}"]${gameData.opening !== 'swap' ? `[Opening "${gameData.opening}"]` : ''}[Player1 "${p1}"][Player2 "${p2}"]`);
 				set2DTimerLive(false);
 				set2DGameTime({
 					time1: time * 1000,
@@ -1019,6 +1025,7 @@ var server = {
 				time_amount: (parseInt(spl[15]) / 60).toString(),
 				opponent: spl[16],
 				bot: spl[17],
+				opening: openingNameFromCode(+(spl[18] || 0)),
 				player_rating: playerRating
 			});
 			this.rendeerseekslist();
@@ -1349,6 +1356,10 @@ var server = {
 				gameTypeText = "Tournament game";
 			}
 
+			// Opening: abbreviation (SS/DBS) for the desktop column, full text for the mobile menu.
+			const openingFull = seek.opening === "double black stack" ? "Double Black Stack" : "Single Swap";
+			const openingAbbr = seek.opening === "double black stack" ? "DBS" : "SS";
+
 			const challengePlayerButton = document.createElement("button");
 			challengePlayerButton.className = "btn btn-transparent seek-button";
 			challengePlayerButton.innerHTML = `<span class='playername'>${seek.player}</span>`;
@@ -1378,6 +1389,7 @@ var server = {
 			$('<td/>').append(seek.pieces+"/"+seek.capstones).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title","Stone count - The number of stones/capstones that each player has in this game").appendTo(row);
 			$('<td/>').append(gameType).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title",gameTypeText).appendTo(row);
 			$('<td/>').append(seek.trigger_move+"/+"+seek.time_amount).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title", "Extra Time - The trigger move the player must reach and the time to add to the clock").appendTo(row);
+			$('<td/>').append(openingAbbr).addClass("right hide-sm").attr("data-toggle", "tooltip").attr("title","Opening - " + openingFull).appendTo(row);
 			// add the same deetails to a dropdown on mobile
 			const dropdownButton = document.createElement("button");
 			dropdownButton.className = "btn btn-transparent dropdown-toggle";
@@ -1430,6 +1442,11 @@ var server = {
 			gameTypeItem.className = "dropdown-item";
 			gameTypeItem.innerHTML = `<strong>Game Type:</strong> ${gameTypeText}`;
 			dropdownMenu.appendChild(gameTypeItem);
+			// opening
+			const openingItem = document.createElement("span");
+			openingItem.className = "dropdown-item";
+			openingItem.innerHTML = `<strong>Opening:</strong> ${openingFull}`;
+			dropdownMenu.appendChild(openingItem);
 			// trigger move
 			const triggerMoveItem = document.createElement("span");
 			triggerMoveItem.className = "dropdown-item";
@@ -1570,7 +1587,8 @@ var server = {
 			capstones: document.getElementById("capcount").value,
 			type: document.getElementById("gametype").value,
 			trigger_move: document.getElementById("triggerMove").value,
-			time_amount: document.getElementById("timeAmount").value
+			time_amount: document.getElementById("timeAmount").value,
+			opening: document.getElementById("openingselect").value
 		};
 		// save the current game seetings to local storage
 		localStorage.setItem("current-game-settings", JSON.stringify(game));
@@ -1578,7 +1596,9 @@ var server = {
 		const unrated = (game.type==2?1:0);
 		const tournament = (game.type==1?1:0);
 		const incParsed = parseIncrementValue(game.increment);
-		const seekCMD =`Seek ${game.size} ${game.time} ${incParsed.increment} ${incParsed.increment_scales ? 1 : 0} ${game.color} ${game.komi} ${game.pieces} ${game.capstones} ${unrated} ${tournament} ${game.trigger_move || 0} ${game.time_amount || 0} ${opponent}`;
+		const opening = openingCodeFromName(game.opening);
+		// protocol 4 seek: opening code (0 = swap, 1 = double black stack) goes before the opponent.
+		const seekCMD =`Seek ${game.size} ${game.time} ${incParsed.increment} ${incParsed.increment_scales ? 1 : 0} ${game.color} ${game.komi} ${game.pieces} ${game.capstones} ${unrated} ${tournament} ${game.trigger_move || 0} ${game.time_amount || 0} ${opening} ${opponent}`;
 		this.send(seekCMD);
 		$('#creategamemodal').modal('hide');
 		server.newSeek = true;
@@ -1690,7 +1710,7 @@ var server = {
 			}
 			// swap the player color for the new seek
 			const newColor = game.my_color === "black" ? "W" : "B";
-			this.send(`Rematch ${game.id} ${game.size} ${game.time} ${game.increment} ${game.incrementScales ? 1 : 0} ${newColor} ${game.komi} ${game.pieces} ${game.capstones} ${game.unrated} ${game.tournament} ${game.triggerMove} ${game.timeAmount} ${game.opponent}`);
+			this.send(`Rematch ${game.id} ${game.size} ${game.time} ${game.increment} ${game.incrementScales ? 1 : 0} ${newColor} ${game.komi} ${game.pieces} ${game.capstones} ${game.unrated} ${game.tournament} ${game.triggerMove} ${game.timeAmount} ${openingCodeFromName(game.opening)} ${game.opponent}`);
 			document.getElementById("rematch").setAttribute("disabled", "disabled");
 			document.getElementById('createSeek').setAttribute("disabled", "disabled");
 			document.getElementById("removeSeek").setAttribute("hidden", "true");


### PR DESCRIPTION
Adds the **"Opening"** selector to the web client. **"Single Swap"** is the default, and support is added for the **"Double Black Stack"** option (where White's first move places a stack of two black flats).  Requires the companion `playtak-api` PR for the protocol-4 wire format.

The notation and header tag follow [PTN Ninja](https://ptn.ninja), which uses `2a1` for the opening stack and the `[Opening "double black stack"]` header. Since the 2D board *is* a PTN Ninja embed, this PR forwards that same `[Opening]` header to it and uses the same `2a1` notation everywhere for consistency.

#### Opening selector
- Added to **Create Game** and **Play Scratch**, with a tooltip explaining each option.
- The selected Opening persists across refreshes like the other Create Game settings.

#### Protocol
- Bumped client to **Protocol 4**; sends/parses the `opening` code in seek, `GameStart`, rematch, reconnect, and spectate (`Observe`) messages.

#### Board rendering & notation
- **3D board:** the two-flat stack stages, lifts, lowers, and places as a single unit — for the placing player, the opponent, and on reconnect — both flats animate together (no teleport).
- **2D board (PTN Ninja):** the `[Opening]` header is forwarded so the embedded board renders the two-flat first ply.
- White's first ply is written `2a1` (PTN Ninja's convention) in the move list and downloaded PTN across online, scratch, reconnect, and spectator views.

#### Join Game & Watch Game modals
To surface the Opening cleanly and bring these tables in line with the games-history (playtak-games) table:
- Consolidated the **Komi**, **Stones/Pieces**, and **Opening** columns into a single **Rules** column that lists only non-default values, each on its own line (e.g. `Komi: 1.5`, `Pieces: 40/2`, `Double Black Stack`). A per-row tooltip explains only the rules that apply.
- Matched the games-history conventions: left-aligned columns; **Time** shown as `10m +10s inc` (with `×n` when the increment scales) and extra time on a second line (`+2m @20`); removed the separate **Extra** column; spelled out the **Type** column (Normal / Unrated / Tournament); komi shown as, e.g., `1.5`.
- The mobile "⋮" detail menu mirrors this: one combined Time Control line, with extra time / komi / pieces / opening shown only when relevant as columns drop out at narrower widths.

#### Compatibility
The Opening defaults to `swap`; existing seeks, games, saved settings, PTN, and pre-protocol-4 clients are unaffected.

#### Testing
Verified in-browser (2D + 3D): scratch and online play, rematch, page-refresh reconnect, spectating, PTN move list / download, settings persistence, and the Join Game / Watch Game table layouts (including the responsive "⋮" menu).

<img width="1233" height="660" alt="PlayTak3DBoardBlackStack" src="https://github.com/user-attachments/assets/d95f4870-32cd-4c84-996d-4f36def2ce5a" />

<img width="642" height="893" alt="image" src="https://github.com/user-attachments/assets/bc62292d-7fa2-4dc0-8e35-9dfb24e7a609" />

<img width="1006" height="686" alt="image" src="https://github.com/user-attachments/assets/7c1df488-0677-4802-a1a9-82688477fe55" />
