### PR TITLE
Improve move-list sidebar and seek/watch table display

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -285,7 +285,7 @@
 						class="rulebox"
 						data-toggle="tooltip" data-placement="auto" title="Komi - If the game ends without a road, black will get this number on top of their flat count when the winner is determined"
 					></span>
-					|
+					<span id="komirule-separator">|</span>
 					<span
 						id="piecerule"
 						class="rulebox"

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -119,7 +119,14 @@ function playScratch(){
 }
 
 function initBoard(){
-	$("#komirule").html("+" + (Math.floor(gameData.komi / 2) || (gameData.komi & 1 ? "" : "0")) + (gameData.komi & 1 ? "&frac12;" : ""));
+	if(gameData.komi > 0){
+		$("#komirule").html("+" + (Math.floor(gameData.komi / 2) || (gameData.komi & 1 ? "" : "0")) + (gameData.komi & 1 ? "&frac12;" : "")).css("display", "");
+		$("#komirule-separator").css("display", "");
+	}
+	else{
+		$("#komirule").css("display", "none");
+		$("#komirule-separator").css("display", "none");
+	}
 	$("#piecerule").html(gameData.pieces + "/" + gameData.capstones);
 	document.getElementById("player-opp").className = "selectplayer";
 	document.getElementById("player-me").className = "";
@@ -811,6 +818,25 @@ function openingNameFromCode(code){
 function openingCodeFromName(name){
 	const i = OPENING_NAMES.indexOf(name);
 	return i < 0 ? 0 : i;
+}
+
+// Time-control display for the seek/watch tables and the playtak-games table.
+// "10 + 20" = 10 min base with a 20 s increment; "10 min" when there's no
+// increment. With increment scaling the increment is shown as n (the move
+// number it scales by): "10 + n", "5 + 2n".
+function formatTimeControl(timeSeconds, increment, incrementScales){
+	const mins = timeSeconds / 60;
+	const inc = Number(increment);
+	if(inc > 0){
+		const incText = incrementScales ? (inc === 1 ? "n" : inc + "n") : inc;
+		return mins + " + " + incText;
+	}
+	return mins + " min";
+}
+// Extra ("byoyomi-style") time display, e.g. "+5 min @35" — 5 minutes added
+// once the game reaches move 35.
+function formatExtraTime(timeAmountMinutes, triggerMove){
+	return "+" + timeAmountMinutes + " min @" + triggerMove;
 }
 
 function isWhitePieceToMove(){

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -1179,11 +1179,11 @@ var server = {
 		const piecesVary = (game.pieces !== stdPieces || game.capstones !== stdCaps);
 		const komiText = Math.floor(game.komi/2) + (game.komi&1 ? ".5" : "");
 		const gameOpeningFull = game.opening === "double black stack" ? "Double Black Stack" : "Single Swap";
-		const timeText = (game.time/60) + "m +" + game.increment + "s" + (game.incrementScales ? "&times;n" : "") + " inc";
+		const timeText = formatTimeControl(game.time, game.increment, game.incrementScales);
 		const hasExtra = (Number(game.triggerMove) > 0 && Number(game.timeAmount) > 0);
-		const extraText = "+" + game.timeAmount + "m @" + game.triggerMove;
+		const extraText = formatExtraTime(game.timeAmount, game.triggerMove);
 		// Time: base time + increment (playtak-games style); extra time on a 2nd line
-		$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", game.incrementScales ? "Time control and increment (n = the current move number)" : "Time control and increment").appendTo(row);
+		$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", game.incrementScales ? "Time (minutes) and increment (seconds). n is the current move number" : "Time (minutes) and increment (seconds)").appendTo(row);
 		// Rules: consolidated komi / pieces / opening (see the seek list for details).
 		const rulesLines = [];
 		const rulesTips = [];
@@ -1405,11 +1405,11 @@ var server = {
 			const stdCaps = [0,0,0,0,0,1,1,2,2][seekSize];
 			const piecesVary = (seek.pieces !== stdPieces || seek.capstones !== stdCaps);
 			const komiText = Math.floor(seek.komi/2) + (seek.komi&1 ? ".5" : "");
-			const timeText = (seek.time/60) + "m +" + seek.increment + "s" + (seek.increment_scales ? "&times;n" : "") + " inc";
+			const timeText = formatTimeControl(seek.time, seek.increment, seek.increment_scales);
 			const hasExtra = (Number(seek.trigger_move) > 0 && Number(seek.time_amount) > 0);
-			const extraText = "+" + seek.time_amount + "m @" + seek.trigger_move;
+			const extraText = formatExtraTime(seek.time_amount, seek.trigger_move);
 			// Time: base time + increment (playtak-games style); extra time on a 2nd line
-			$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", seek.increment_scales ? "Time control and increment (n = the current move number)" : "Time control and increment").appendTo(row);
+			$('<td/>').append(timeText + (hasExtra ? "<br>" + extraText : "")).addClass("time-rule").attr("data-toggle", "tooltip").attr("title", seek.increment_scales ? "Time (minutes) and increment (seconds). n is the current move number" : "Time (minutes) and increment (seconds)").appendTo(row);
 			// Rules: consolidated komi / pieces / opening. Only non-default values are
 			// shown, each on its own line. The opening name appears without an "Opening:"
 			// label (kept compact via a smaller, wrappable font); the per-row tooltip


### PR DESCRIPTION
## Summary
Display/formatting polish for the move-list sidebar and the Join Game / Watch Game tables. No protocol or gameplay changes.

## Background
While testing in beta, Boris and I both found the current format for `+n` time controls (e.g. `10m + 1sxn inc`) to be confusing/hard to parse. He and I talked through several options for ways to tweak it, and this PR contains the option that seemed clearest. 

Interestingly, what we arrived at is essentially the same approach Chess.com uses in their UIs. This was purely coincidence—Boris and I only realized it after independently deciding that it seemed best. I only mention this point here to show that there's good precedent for the direction this PR goes.

## Changes
- **Reformat time controls** in the Join Game and Watch Game tables and their mobile detail popups to better accommodate the new `+n` options. 
  - `10 + 20` — base minutes + increment seconds
  - `10 min` — when there's no increment
  - `10 + n`, `5 + 2n` — when the increment scales by move number (the `n` is shown as the increment itself instead of `×n`)
  - `+5 min @35` — extra time
- **Time column tooltip** now reads *"Time (minutes) and increment (seconds)"*, with *"n is the current move number"* appended when the increment scales.
- **Additional fix: hide komi when it's zero** in the in-game move-list sidebar — it no longer shows a meaningless `+0`. The komi value (and its separator) only render when komi > 0.

## Testing
- Verified formatting against all cases (with/without increment, scaling inc=1/inc=2, extra time) and confirmed the sidebar no longer shows `+0`.
- Lints clean on the changed files.

## Screenshots
<img width="983" height="195" alt="image" src="https://github.com/user-attachments/assets/0e2b10ee-0305-41f7-ae02-f4c14589d080" />

<img width="991" height="275" alt="image" src="https://github.com/user-attachments/assets/d3966a3c-73c1-4b68-9e0f-8a01e4a223da" />
