### PR TITLE
Fix Double Black Stack board repopulation on 2D/3D toggle

### DIFF
--- a/src/js/board.js
+++ b/src/js/board.js
@@ -3751,8 +3751,28 @@ const board = {
 
 		for(let ply = 0;ply < parsed.moves.length;ply++){
 			const move = parsed.moves[ply];
-			let match;
-			if((match = /^([SFC]?)([a-h])([0-8])$/.exec(move)) !== null){
+			let match, dbsMatch;
+			// Double Black Stack: White's opening ply is stored as "2a1" (a 2-flat
+			// black stack). That token matches neither notation pattern below, so
+			// without this branch the ply is dropped and every later move loads with
+			// the wrong colour/position (move_count never advances). Mirror live play
+			// (addDoubleBlackStackFlatIfApplicable): place the swapped black flat,
+			// then a second black flat on top.
+			if(gameData.opening === 'double black stack' && gameData.move_count === 0 &&
+				(dbsMatch = /^2([a-h])([0-8])$/.exec(move)) !== null){
+				const file = dbsMatch[1].charCodeAt(0) - 'a'.charCodeAt(0);
+				const rank = parseInt(dbsMatch[2]) - 1;
+				const obj = this.getfromstack(false, false); // a black flat
+				if(!obj){
+					console.warn("bad PTN: too many pieces");
+					return;
+				}
+				const hlt = this.get_board_obj(file,rank);
+				this.pushPieceOntoSquare(hlt,obj);
+				this.addDoubleBlackStackFlatIfApplicable(hlt);
+				this.lastMovedSquareList.push({file: hlt.file, rank: hlt.rank});
+			}
+			else if((match = /^([SFC]?)([a-h])([0-8])$/.exec(move)) !== null){
 				const piece = match[1];
 				const file = match[2].charCodeAt(0) - 'a'.charCodeAt(0);
 				const rank = parseInt(match[3]) - 1;

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -301,7 +301,11 @@ function loadCurrentGameState(){
 		set2DBoard(currentGame);
 		send2DAction('LAST');
 		for(let i = 0; i < parsed.moves.length; i++){
-			if((/^([SFC]?)([a-h])([0-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
+			// Double Black Stack: White's opening ply "2a1" is a valid 2-flat black
+			// stack placement, but it matches neither pattern below, so accept it
+			// explicitly — otherwise the move list rebuilds a move short and misaligned.
+			const isDbsOpen = (i === 0 && gameData.opening === 'double black stack' && /^2[a-h][0-8]$/.test(parsed.moves[i]));
+			if(!isDbsOpen && (/^([SFC]?)([a-h])([0-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
 				console.warn("unparseable: " + parsed.moves[i]);
 				continue;
 			}


### PR DESCRIPTION
## Summary
Fixes a bug (reported on beta) where toggling between the 3D board and the PTN Ninja (2D) board mid-game left the board incorrectly repopulated in a **Double Black Stack** game.

## Root cause
Each toggle rebuilds the target board from the stored PTN. White's DBS opening ply is stored as `2a1` (a 2-flat black stack), which matched neither the placement pattern (`/^([SFC]?)([a-h])([0-8])$/`) nor the movement pattern in the repopulation code:

- `board.loadptn` (3D) dropped the opening ply entirely. Because `move_count` never advanced, every later move then loaded with the wrong colour/position — e.g. a `2a1 f6` game loaded **1 piece instead of 3**.
- `loadCurrentGameState` (2D move-list rebuild) skipped `2a1`, rebuilding the notation a move short and misaligned.

## Fix
Handle the `2a1` opening ply in both repopulation paths:
- `board.loadptn` places the swapped black flat plus a second black flat on top, mirroring live play's `addDoubleBlackStackFlatIfApplicable`.
- The 2D move-list rebuild accepts the `2a1` token.

## Testing
- Verified locally in-app: DBS `2a1 f6` → 3 pieces (a1 stack = 2, f6 white); `2a1 f6 / b2 e5` → 5 pieces (black 3, white 2).
- Regression-checked normal games, stack movements, walls, and capstones — all still load correctly.
- Confirmed by toggling 3D ↔ PTN Ninja mid-DBS-game in the browser.

<img width="1664" height="918" alt="PlayTakDBSRepopulateAfterToggle2d3d" src="https://github.com/user-attachments/assets/26bd6fa8-38c7-49d6-a62a-0d597fc2751c" />
