### PR TITLE
Restore the opening variant on every PTN load path

### DIFF
--- a/src/js/board.js
+++ b/src/js/board.js
@@ -3769,6 +3769,14 @@ const board = {
 				(dbsMatch = /^2([a-h])([0-8])$/.exec(move)) !== null){
 				const file = dbsMatch[1].charCodeAt(0) - 'a'.charCodeAt(0);
 				const rank = parseInt(dbsMatch[2]) - 1;
+				// The pattern spans the whole a-h/0-8 notation space, so it also matches
+				// rank 0 and squares past the edge of this board. get_board_obj would
+				// index outside this.sq and throw, aborting the load half-finished, so
+				// treat an off-board square the same as any other unparseable ply.
+				if(file >= size || rank < 0 || rank >= size){
+					console.warn("unparseable: " + move);
+					continue;
+				}
 				const obj = this.getfromstack(false, false); // a black flat
 				if(!obj){
 					console.warn("bad PTN: too many pieces");

--- a/src/js/board.js
+++ b/src/js/board.js
@@ -2104,6 +2104,15 @@ const board = {
 	get_board_obj: function(file,rank){
 		return this.sq[file][gameData.size - 1 - rank].board_object;
 	},
+	// Square notation spans the largest board (a-h, 1-8), so a coordinate parsed
+	// from a PTN can name a square this board does not have. get_board_obj would
+	// index outside this.sq and throw, so callers handling untrusted notation
+	// must check first. Uses the allocated dimension rather than gameData.size,
+	// which load() leaves as a string from the PTN tag.
+	isOnBoard: function(file,rank){
+		const n = this.sq.length;
+		return file >= 0 && file < n && rank >= 0 && rank < n;
+	},
 	incmovecnt: function(){
 		this.save_board_pos();
 		incrementMoveCounter();
@@ -3769,11 +3778,7 @@ const board = {
 				(dbsMatch = /^2([a-h])([1-8])$/.exec(move)) !== null){
 				const file = dbsMatch[1].charCodeAt(0) - 'a'.charCodeAt(0);
 				const rank = parseInt(dbsMatch[2]) - 1;
-				// The pattern spans the largest board, so it also matches squares past
-				// the edge of this one. get_board_obj would index outside this.sq and
-				// throw, aborting the load half-finished, so treat an off-board square
-				// the same as any other unparseable ply.
-				if(file >= size || rank >= size){
+				if(!this.isOnBoard(file,rank)){
 					console.warn("unparseable: " + move);
 					continue;
 				}
@@ -3787,10 +3792,14 @@ const board = {
 				this.addDoubleBlackStackFlatIfApplicable(hlt);
 				this.lastMovedSquareList.push({file: hlt.file, rank: hlt.rank});
 			}
-			else if((match = /^([SFC]?)([a-h])([0-8])$/.exec(move)) !== null){
+			else if((match = /^([SFC]?)([a-h])([1-8])$/.exec(move)) !== null){
 				const piece = match[1];
 				const file = match[2].charCodeAt(0) - 'a'.charCodeAt(0);
 				const rank = parseInt(match[3]) - 1;
+				if(!this.isOnBoard(file,rank)){
+					console.warn("unparseable: " + move);
+					continue;
+				}
 				const obj = this.getfromstack((piece === 'C'),isWhitePieceToMove());
 				if(!obj){
 					console.warn("bad PTN: too many pieces");
@@ -3803,7 +3812,7 @@ const board = {
 				this.pushPieceOntoSquare(hlt,obj);
 				this.lastMovedSquareList.push({file: hlt.file, rank: hlt.rank});
 			}
-			else if((match = /^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(move)) !== null){
+			else if((match = /^([1-9]?)([a-h])([1-8])([><+-])(\d*)$/.exec(move)) !== null){
 				const count = match[1];
 				const file = match[2].charCodeAt(0) - 'a'.charCodeAt(0);
 				const rank = parseInt(match[3]) - 1;
@@ -3832,6 +3841,16 @@ const board = {
 				}
 				else if(dir == '+'){
 					dr = 1;
+				}
+
+				// Validate the whole path up front. get_stack returns the live stack and
+				// the drop loop mutates squares as it goes, so discovering an off-board
+				// square partway through would leave a half-applied move on the board.
+				// The drops run in a straight line, so the endpoints bound the rest.
+				if(!this.isOnBoard(file,rank)
+					|| !this.isOnBoard(file + drops.length * df, rank + drops.length * dr)){
+					console.warn("unparseable: " + move);
+					continue;
 				}
 
 				const s1 = this.get_board_obj(file,rank);

--- a/src/js/board.js
+++ b/src/js/board.js
@@ -3766,14 +3766,14 @@ const board = {
 			// (addDoubleBlackStackFlatIfApplicable): place the swapped black flat,
 			// then a second black flat on top.
 			if(gameData.opening === 'double black stack' && gameData.move_count === 0 &&
-				(dbsMatch = /^2([a-h])([0-8])$/.exec(move)) !== null){
+				(dbsMatch = /^2([a-h])([1-8])$/.exec(move)) !== null){
 				const file = dbsMatch[1].charCodeAt(0) - 'a'.charCodeAt(0);
 				const rank = parseInt(dbsMatch[2]) - 1;
-				// The pattern spans the whole a-h/0-8 notation space, so it also matches
-				// rank 0 and squares past the edge of this board. get_board_obj would
-				// index outside this.sq and throw, aborting the load half-finished, so
-				// treat an off-board square the same as any other unparseable ply.
-				if(file >= size || rank < 0 || rank >= size){
+				// The pattern spans the largest board, so it also matches squares past
+				// the edge of this one. get_board_obj would index outside this.sq and
+				// throw, aborting the load half-finished, so treat an off-board square
+				// the same as any other unparseable ply.
+				if(file >= size || rank >= size){
 					console.warn("unparseable: " + move);
 					continue;
 				}

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -278,7 +278,7 @@ function load(){
 				// parsePTN leaves empty-valued tags such as [Result ""] in the move array,
 				// so the opening ply is not reliably at index 0.
 				const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][1-8]$/.test(parsed.moves[i]));
-				if(!isDbsOpen && (/^([SFC]?)([a-h])([0-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
+				if(!isDbsOpen && (/^([SFC]?)([a-h])([1-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([1-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
 					console.warn("unparseable: " + parsed.moves[i]);
 					continue;
 				}
@@ -334,7 +334,7 @@ function loadCurrentGameState(){
 			// parsePTN leaves empty-valued tags such as [Result ""] in the move array,
 			// so the opening ply is not reliably at index 0.
 			const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][1-8]$/.test(parsed.moves[i]));
-			if(!isDbsOpen && (/^([SFC]?)([a-h])([0-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
+			if(!isDbsOpen && (/^([SFC]?)([a-h])([1-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([1-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
 				console.warn("unparseable: " + parsed.moves[i]);
 				continue;
 			}

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -16,6 +16,7 @@ let gameData = {
 	capstones: 1,
 	unrated: false,
 	tournament: false,
+	opening: 'swap',
 	triggerMove: 0,
 	timeAmount: 0,
 	bot: 0,
@@ -252,6 +253,10 @@ function load(){
 		gameData.komi = parsed.tags.Komi || 0;
 		gameData.pieces = parsed.tags.Flats || defaultPiecesAndCaps[gameData.size][0];
 		gameData.capstones = parsed.tags.Caps || defaultPiecesAndCaps[gameData.size][1];
+		// The opening variant drives how White's first ply is notated and rendered
+		// (Double Black Stack writes it as "2a1"), so it has to be restored from the
+		// tag before any move is validated or replayed below.
+		gameData.opening = (parsed.tags.Opening || 'swap').trim().toLowerCase();
 	}
 	else if(!parsed && !isTPS){
 		alert('warning','Invalid PTN/TPS');
@@ -266,7 +271,14 @@ function load(){
 				parsed.moves.pop();
 			}
 			for(let i = 0; i < parsed.moves.length; i++){
-				if((/^([SFC]?)([a-h])([0-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
+				// Double Black Stack: White's opening ply "2a1" is a valid 2-flat black
+				// stack placement, but it matches neither pattern below, so accept it
+				// explicitly — otherwise the move list rebuilds a move short and misaligned.
+				// Keyed off move_count (as board.loadptn is) rather than the loop index:
+				// parsePTN leaves empty-valued tags such as [Result ""] in the move array,
+				// so the opening ply is not reliably at index 0.
+				const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][0-8]$/.test(parsed.moves[i]));
+				if(!isDbsOpen && (/^([SFC]?)([a-h])([0-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
 					console.warn("unparseable: " + parsed.moves[i]);
 					continue;
 				}
@@ -302,6 +314,13 @@ function loadCurrentGameState(){
 		return;
 	}
 	const parsed = parsePTN(currentGame);
+	// The stored PTN carries the opening variant, so honour it here too — the
+	// board-mode toggle can run against game data that never saw a Game Start
+	// (e.g. a PTN pasted through Load Game). Only override when the tag is
+	// actually present, so a live game's opening is never clobbered.
+	if(parsed && parsed.tags && parsed.tags.Opening){
+		gameData.opening = parsed.tags.Opening.trim().toLowerCase();
+	}
 	clearNotationMenu();
 	initCounters(0);
 	if(is2DBoard){
@@ -311,7 +330,10 @@ function loadCurrentGameState(){
 			// Double Black Stack: White's opening ply "2a1" is a valid 2-flat black
 			// stack placement, but it matches neither pattern below, so accept it
 			// explicitly — otherwise the move list rebuilds a move short and misaligned.
-			const isDbsOpen = (i === 0 && gameData.opening === 'double black stack' && /^2[a-h][0-8]$/.test(parsed.moves[i]));
+			// Keyed off move_count (as board.loadptn is) rather than the loop index:
+			// parsePTN leaves empty-valued tags such as [Result ""] in the move array,
+			// so the opening ply is not reliably at index 0.
+			const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][0-8]$/.test(parsed.moves[i]));
 			if(!isDbsOpen && (/^([SFC]?)([a-h])([0-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
 				console.warn("unparseable: " + parsed.moves[i]);
 				continue;

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -277,7 +277,7 @@ function load(){
 				// Keyed off move_count (as board.loadptn is) rather than the loop index:
 				// parsePTN leaves empty-valued tags such as [Result ""] in the move array,
 				// so the opening ply is not reliably at index 0.
-				const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][0-8]$/.test(parsed.moves[i]));
+				const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][1-8]$/.test(parsed.moves[i]));
 				if(!isDbsOpen && (/^([SFC]?)([a-h])([0-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
 					console.warn("unparseable: " + parsed.moves[i]);
 					continue;
@@ -333,7 +333,7 @@ function loadCurrentGameState(){
 			// Keyed off move_count (as board.loadptn is) rather than the loop index:
 			// parsePTN leaves empty-valued tags such as [Result ""] in the move array,
 			// so the opening ply is not reliably at index 0.
-			const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][0-8]$/.test(parsed.moves[i]));
+			const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][1-8]$/.test(parsed.moves[i]));
 			if(!isDbsOpen && (/^([SFC]?)([a-h])([0-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([0-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
 				console.warn("unparseable: " + parsed.moves[i]);
 				continue;


### PR DESCRIPTION
## Summary

Double Black Stack notates White's opening ply as `2a1`, so any code that replays a PTN has to know the opening before it validates moves. Several gaps meant it usually did not.

This addresses the review feedback on the DBS load paths, plus two related problems found while verifying that feedback.

## What was broken

**1. `load()` never restored `[Opening]`.** It calls `resetGameDataToDefault()` (opening → `swap`) and restores Size/Komi/Flats/Caps from the tags, but not Opening. Loading a Double Black Stack PTN on `dev`:

| | before | expected |
|---|---|---|
| 3D board | `a1` empty, `e5` = black | `a1` = two black flats, `e5` = white |
| move list | `1. e5 c3 / 2. c4 b3 / 3. d3` | `1. 2a1 e5 / 2. c3 c4 / 3. b3 d3` |
| `move_count` | 5 | 6 |

The 3D board dropped `2a1` as unparseable and, because `move_count` never advanced, every later ply loaded with the wrong colour and square. The 2D move list rebuilt a ply short and misaligned. This affects Download PTN → Load Game, `?load=` review links, and PTNs copied from playtak.com/games.

**2. `loadCurrentGameState()` never restored it either**, so the board-mode toggle inherited whatever the previous path had left behind.

**3. The `gameData` literal omitted `opening`** (`resetGameDataToDefault` has it), so a fresh page load in 2D mode sent PTN Ninja `[Opening "undefined"]`.

**4. The existing first-ply exception did not actually fire.** It keyed off the loop index `i === 0`, but `getNotation()` always writes `[Result ""]` and `parsePTN`'s tag pattern requires a non-empty value — so `[Result ""]` survives into `parsed.moves` as two tokens and pushes the opening ply to index 2. Verified on current `dev`: the 2D/3D toggle still dropped `2a1`. Both loops now key off `move_count === 0`, matching what `board.loadptn` already does.

**5. Off-board Double Black Stack squares threw.** `/^2([a-h])([0-8])$/` spans the whole notation space, so `2a0` (rank −1) or an off-board `2f6` on a 5x5 reached `get_board_obj`, indexed outside `this.sq` and threw a `TypeError`, aborting the load half-finished with no user-facing error. These are now reported as unparseable like any other bad ply.

Worth noting: (5) was unreachable before this PR, because `load()` forced the opening to `swap` and the only other caller replays server-authoritative notation. It becomes reachable the moment (1) is fixed, which is why it belongs in the same change.

## Testing

Verified in the browser against a local stack, on 5x5 and 6x6:

- Double Black Stack PTN via Load Game and via `?load=` — correct board and correct move list, in both 2D and 3D
- `[Opening "Double Black Stack"]` (title-cased) also accepted
- live-game 2D/3D toggle rebuild
- `2a0` and off-board `2f6` on a 5x5 — clean `unparseable` warning, no exception, following plies still load
- plain swap PTNs unchanged

`npx eslint` on both files: 0 errors. `npx vitest run`: 9/9 pass.

## Out of scope, but noticed while here

- `loadCurrentGameState()` throws `ReferenceError: lastTimeUpdate is not defined` in any scratch or review game: `lastTimeUpdate` is an implicit global created only by `server.js`'s Time handler, since `server.js:181`'s `lastTimeUpdate: null` is a property of the `server` object rather than the global. It throws after the move-list rebuild, so it does not affect the behaviour above. Separate PR if wanted.
- `parsePTN` drops empty-valued tags into `moves`, producing two spurious `unparseable` warnings on every stored-game load. Relaxing the pattern to `[^"]*` would make `[Result ""]` fire `gameOver()` in `loadptn`, so it needs its own change.
"