### PR TITLE
fix(load): read the Clock tag instead of printing it, and restore the rules row

### DIFF
--- a/src/js/board.js
+++ b/src/js/board.js
@@ -3792,7 +3792,7 @@ const board = {
 				this.addDoubleBlackStackFlatIfApplicable(hlt);
 				this.lastMovedSquareList.push({file: hlt.file, rank: hlt.rank});
 			}
-			else if((match = /^([SFC]?)([a-h])([1-8])$/.exec(move)) !== null){
+			else if((match = matchPTNPlacement(move)) !== null){
 				const piece = match[1];
 				const file = match[2].charCodeAt(0) - 'a'.charCodeAt(0);
 				const rank = parseInt(match[3]) - 1;
@@ -3812,7 +3812,7 @@ const board = {
 				this.pushPieceOntoSquare(hlt,obj);
 				this.lastMovedSquareList.push({file: hlt.file, rank: hlt.rank});
 			}
-			else if((match = /^([1-9]?)([a-h])([1-8])([><+-])(\d*)$/.exec(move)) !== null){
+			else if((match = matchPTNMovement(move)) !== null){
 				const count = match[1];
 				const file = match[2].charCodeAt(0) - 'a'.charCodeAt(0);
 				const rank = parseInt(match[3]) - 1;

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -119,7 +119,10 @@ function playScratch(){
 	$("#creategamemodal").modal("hide");
 }
 
-function initBoard(){
+// Populate the rules row beneath the players — komi, stone counts, increment,
+// extra time — from gameData. Split out of initBoard so a game loaded from a
+// PTN can show the same information without also resetting the board.
+function renderVariableRules(){
 	if(gameData.komi > 0){
 		$("#komirule").html("+" + (Math.floor(gameData.komi / 2) || (gameData.komi & 1 ? "" : "0")) + (gameData.komi & 1 ? "&frac12;" : "")).css("display", "");
 		$("#komirule-separator").css("display", "");
@@ -129,8 +132,6 @@ function initBoard(){
 		$("#komirule-separator").css("display", "none");
 	}
 	$("#piecerule").html(gameData.pieces + "/" + gameData.capstones);
-	document.getElementById("player-opp").className = "selectplayer";
-	document.getElementById("player-me").className = "";
 
 	if(gameData.increment > 0){
 		document.getElementById("time-increment").style.display = 'block';
@@ -157,6 +158,13 @@ function initBoard(){
 		document.getElementById("extra-time-rule").style.display = 'block';
 		document.getElementById("extra-time-rule").innerHTML = `${gameData.triggerMove}/+${gameData.timeAmount/60}`;
 	}
+}
+
+function initBoard(){
+	renderVariableRules();
+	document.getElementById("player-opp").className = "selectplayer";
+	document.getElementById("player-me").className = "";
+
 	// reset the game data and set new values
 	if(!is2DBoard){
 		board.clear();
@@ -245,18 +253,36 @@ function load(){
 		}
 		$('.player1-name:first').html(parsed.tags.Player1);
 		$('.player2-name:first').html(parsed.tags.Player2);
-		if(parsed.tags.Clock !== undefined){
-			$('.player1-time:first').html(parsed.tags.Clock);
-			$('.player2-time:first').html(parsed.tags.Clock);
+		// The Clock tag is a time control, not a remaining time, so writing it
+		// into the clocks verbatim put "10:0 +20 @35 +10:0" where a countdown
+		// belongs. Read it apart: the base duration starts both clocks, and the
+		// increment and bonus belong in the rules row, rendered further below.
+		const clock = parsePTNClock(parsed.tags.Clock);
+		if(clock){
+			gameData.time = clock.time;
+			gameData.increment = clock.increment;
+			gameData.incrementScales = clock.incrementScales;
+			gameData.triggerMove = clock.triggerMove;
+			gameData.timeAmount = clock.timeAmount;
+			$('.player1-time:first').html(formatTime(clock.time * 1000));
+			$('.player2-time:first').html(formatTime(clock.time * 1000));
 		}
 		gameData.size = parsed.tags.Size;
-		gameData.komi = parsed.tags.Komi || 0;
+		// gameData.komi is half-komi everywhere else — the server assigns the raw
+		// field and every consumer halves it — but the Komi tag holds the whole
+		// value, so it has to be doubled on the way in. Without this the komi was
+		// halved for the rules row below, for the flat count, and again on export.
+		gameData.komi = (Number(parsed.tags.Komi) || 0) * 2;
 		gameData.pieces = parsed.tags.Flats || defaultPiecesAndCaps[gameData.size][0];
 		gameData.capstones = parsed.tags.Caps || defaultPiecesAndCaps[gameData.size][1];
 		// The opening variant drives how White's first ply is notated and rendered
 		// (Double Black Stack writes it as "2a1"), so it has to be restored from the
 		// tag before any move is validated or replayed below.
 		gameData.opening = (parsed.tags.Opening || 'swap').trim().toLowerCase();
+		// The rules row was cleared by clearNotationMenu above and, unlike a game
+		// started from the server, nothing repopulated it — initBoard does that,
+		// but calling it here would reset the board we are about to load into.
+		renderVariableRules();
 	}
 	else if(!parsed && !isTPS){
 		alert('warning','Invalid PTN/TPS');

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -304,7 +304,7 @@ function load(){
 				// parsePTN leaves empty-valued tags such as [Result ""] in the move array,
 				// so the opening ply is not reliably at index 0.
 				const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][1-8]$/.test(parsed.moves[i]));
-				if(!isDbsOpen && (/^([SFC]?)([a-h])([1-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([1-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
+				if(!isDbsOpen && matchPTNPlacement(parsed.moves[i]) === null && matchPTNMovement(parsed.moves[i]) === null){
 					console.warn("unparseable: " + parsed.moves[i]);
 					continue;
 				}
@@ -360,7 +360,7 @@ function loadCurrentGameState(){
 			// parsePTN leaves empty-valued tags such as [Result ""] in the move array,
 			// so the opening ply is not reliably at index 0.
 			const isDbsOpen = (gameData.move_count === 0 && gameData.opening === 'double black stack' && /^2[a-h][1-8]$/.test(parsed.moves[i]));
-			if(!isDbsOpen && (/^([SFC]?)([a-h])([1-8])$/.exec(parsed.moves[i])) === null && (/^([1-9]?)([a-h])([1-8])([><+-])(\d*)$/.exec(parsed.moves[i])) === null){
+			if(!isDbsOpen && matchPTNPlacement(parsed.moves[i]) === null && matchPTNMovement(parsed.moves[i]) === null){
 				console.warn("unparseable: " + parsed.moves[i]);
 				continue;
 			}

--- a/src/js/ptn.js
+++ b/src/js/ptn.js
@@ -38,6 +38,42 @@ function parsePTNMoves(body){
 	return moves;
 }
 
+// "3:0:0", "10:0" and "30" are hours:minutes:seconds, minutes:seconds and
+// seconds respectively — the shapes the Clock tag uses for a duration.
+function ptnDurationToSeconds(text){
+	return String(text).split(":").reduce((total, part) => total * 60 + (parseInt(part, 10) || 0), 0);
+}
+
+// Read a PTN Clock tag into the fields the interface keeps on gameData.
+//
+// The tag is a time control, not a remaining time: a base duration, an
+// optional increment (with a trailing "n" when it scales with the move
+// number), and an optional "@move +duration" bonus. e.g.
+//   "10:0 +20"              10 minutes, 20 second increment
+//   "3:0:0 +1n"             3 hours, increment of 1 second per move elapsed
+//   "10:0 +20 @35 +10:0"    ...plus 10 minutes granted at move 35
+//
+// Returns null when the tag does not start with a duration, so callers can
+// leave their defaults alone rather than zeroing a clock over a stray value.
+function parsePTNClock(clock){
+	if(!clock){
+		return null;
+	}
+	const match = String(clock).trim().match(
+		/^(\d+(?::\d+){0,2})(?:\s*\+(\d+)(n)?)?(?:\s*@(\d+)\s*\+(\d+(?::\d+){0,2}))?/i
+	);
+	if(!match){
+		return null;
+	}
+	return {
+		time: ptnDurationToSeconds(match[1]),
+		increment: match[2] ? parseInt(match[2], 10) : 0,
+		incrementScales: Boolean(match[3]),
+		triggerMove: match[4] ? parseInt(match[4], 10) : 0,
+		timeAmount: match[5] ? ptnDurationToSeconds(match[5]) : 0
+	};
+}
+
 // Play Tak Server notation conversion functions
 // copied from https://gist.github.com/gruppler/031b8863b9439700d5ab30694aab0b9d
 // takes in psn and converts it to ptn

--- a/src/js/ptn.js
+++ b/src/js/ptn.js
@@ -38,6 +38,32 @@ function parsePTNMoves(body){
 	return moves;
 }
 
+// A ply is either a placement ("a1", "Sc3", "Cd4") or a movement
+// ("3c3>111", "a1+"). Both were written inline at each load site, which is how
+// they drifted apart; keep them here so every caller reads the same notation.
+//
+// Ranks are 1-8 and drop counts are 1-8: rank 0 would index off the front of
+// the grid (parseInt(rank) - 1 === -1) and a drop of 0 moves no pieces, so
+// neither can appear in real notation. Leaving them in the character class let
+// a malformed ply corrupt the board silently instead of being rejected here.
+//
+// The drop list stays optional, because both numbers are implied when absent:
+// an omitted count is 1, and an omitted drop list means the whole count lands
+// on a single square. So "a1+" moves one piece to a2, and "3a1+" drops all
+// three on a2. The caller fills those in.
+const PTN_PLACEMENT_RE = /^([SFC]?)([a-h])([1-8])$/;
+const PTN_MOVEMENT_RE = /^([1-9]?)([a-h])([1-8])([><+-])([1-8]*)$/;
+
+// Both return the match (with capture groups) or null, so callers can either
+// test for validity or read the parts out.
+function matchPTNPlacement(move){
+	return PTN_PLACEMENT_RE.exec(move);
+}
+
+function matchPTNMovement(move){
+	return PTN_MOVEMENT_RE.exec(move);
+}
+
 // "3:0:0", "10:0" and "30" are hours:minutes:seconds, minutes:seconds and
 // seconds respectively — the shapes the Clock tag uses for a duration.
 function ptnDurationToSeconds(text){

--- a/src/js/tests/parse-ptn-clock.test.js
+++ b/src/js/tests/parse-ptn-clock.test.js
@@ -1,0 +1,79 @@
+/**
+ * Tests for parsePTNClock.
+ *
+ * The PTN Clock tag is a time control, not a remaining time: a base duration,
+ * an optional increment (with a trailing "n" when it scales with the move
+ * number), and an optional "@move +duration" bonus. Loading a PTN used to
+ * write the whole tag into both clock displays, so "10:0 +20 @35 +10:0"
+ * appeared where a countdown belongs and the increment and bonus never
+ * reached the rules row.
+ */
+
+import {describe, it, expect}from 'vitest';
+import {readFileSync}from 'fs';
+import {fileURLToPath}from 'url';
+import path from 'path';
+
+// ptn.js is a plain script of globals rather than a module, so evaluate it and
+// pull the function out instead of importing it.
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.join(here, '..', 'ptn.js'), 'utf8');
+const start = source.indexOf('function ptnDurationToSeconds');
+const end = source.indexOf('// Play Tak Server notation');
+const {parsePTNClock} = new Function(
+	source.slice(start, end) + '\nreturn {parsePTNClock};'
+)();
+
+describe('parsePTNClock', () => {
+	it('reads a base duration in each of its shapes', () => {
+		expect(parsePTNClock('30').time).toEqual(30);
+		expect(parsePTNClock('1:30').time).toEqual(90);
+		expect(parsePTNClock('10:0').time).toEqual(600);
+		expect(parsePTNClock('3:0:0').time).toEqual(10800);
+	});
+
+	it('reads a fixed increment', () => {
+		const clock = parsePTNClock('10:0 +20');
+		expect(clock.increment).toEqual(20);
+		expect(clock.incrementScales).toEqual(false);
+	});
+
+	it('reads an increment that scales with the move number', () => {
+		const clock = parsePTNClock('3:0:0 +1n');
+		expect(clock.time).toEqual(10800);
+		expect(clock.increment).toEqual(1);
+		expect(clock.incrementScales).toEqual(true);
+	});
+
+	it('reads bonus time granted at a move', () => {
+		const clock = parsePTNClock('10:0 +20 @35 +10:0');
+		expect(clock.triggerMove).toEqual(35);
+		expect(clock.timeAmount).toEqual(600);
+	});
+
+	it('reads a time control using every part at once', () => {
+		expect(parsePTNClock('3:0:0 +1n @30 +5:0')).toEqual({
+			time: 10800,
+			increment: 1,
+			incrementScales: true,
+			triggerMove: 30,
+			timeAmount: 300
+		});
+	});
+
+	it('defaults the optional parts to zero', () => {
+		expect(parsePTNClock('5:0')).toEqual({
+			time: 300,
+			increment: 0,
+			incrementScales: false,
+			triggerMove: 0,
+			timeAmount: 0
+		});
+	});
+
+	it('returns null rather than zeroing the clock for a missing or unreadable tag', () => {
+		expect(parsePTNClock(undefined)).toEqual(null);
+		expect(parsePTNClock('')).toEqual(null);
+		expect(parsePTNClock('garbage')).toEqual(null);
+	});
+});

--- a/src/js/tests/parse-ptn-move.test.js
+++ b/src/js/tests/parse-ptn-move.test.js
@@ -1,0 +1,103 @@
+/**
+ * Tests for matchPTNPlacement and matchPTNMovement.
+ *
+ * The two ply patterns were written inline at each PTN load site, and drifted:
+ * ranks were matched as [0-8] and drop counts as \d*, so "a0" and "a1>0" were
+ * accepted. Neither is real notation — rank 0 becomes y === -1 (an index off
+ * the front of the grid) and a drop of 0 moves no pieces — and both corrupted
+ * the board silently rather than being rejected at the parse.
+ */
+
+import {describe, it, expect}from 'vitest';
+import {readFileSync}from 'fs';
+import {fileURLToPath}from 'url';
+import path from 'path';
+
+// ptn.js is a plain script of globals rather than a module, so evaluate it and
+// pull the functions out instead of importing it.
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.join(here, '..', 'ptn.js'), 'utf8');
+const start = source.indexOf('const PTN_PLACEMENT_RE');
+const end = source.indexOf('function ptnDurationToSeconds');
+const {matchPTNPlacement, matchPTNMovement} = new Function(
+	source.slice(start, end) + '\nreturn {matchPTNPlacement, matchPTNMovement};'
+)();
+
+describe('matchPTNPlacement', () => {
+	it('accepts a flat, wall and capstone on every rank', () => {
+		expect(matchPTNPlacement('a1')).not.toEqual(null);
+		expect(matchPTNPlacement('Sc3')).not.toEqual(null);
+		expect(matchPTNPlacement('Cd4')).not.toEqual(null);
+		expect(matchPTNPlacement('Fh8')).not.toEqual(null);
+	});
+
+	it('reads the piece, file and rank into capture groups', () => {
+		const match = matchPTNPlacement('Sc3');
+		expect(match[1]).toEqual('S');
+		expect(match[2]).toEqual('c');
+		expect(match[3]).toEqual('3');
+	});
+
+	it('rejects rank 0, which would index off the front of the grid', () => {
+		expect(matchPTNPlacement('a0')).toEqual(null);
+		expect(matchPTNPlacement('Sc0')).toEqual(null);
+	});
+
+	it('rejects squares off the far edge of the largest board', () => {
+		expect(matchPTNPlacement('a9')).toEqual(null);
+		expect(matchPTNPlacement('i1')).toEqual(null);
+	});
+
+	it('rejects a movement, so callers fall through to the movement pattern', () => {
+		expect(matchPTNPlacement('3c3>111')).toEqual(null);
+	});
+});
+
+describe('matchPTNMovement', () => {
+	it('accepts a movement in each of its shapes', () => {
+		expect(matchPTNMovement('a1+')).not.toEqual(null);
+		expect(matchPTNMovement('3c3>111')).not.toEqual(null);
+		expect(matchPTNMovement('2d4-11')).not.toEqual(null);
+		expect(matchPTNMovement('5e5<32')).not.toEqual(null);
+	});
+
+	it('reads the count, square, direction and drops into capture groups', () => {
+		const match = matchPTNMovement('3c3>111');
+		expect(match[1]).toEqual('3');
+		expect(match[2]).toEqual('c');
+		expect(match[3]).toEqual('3');
+		expect(match[4]).toEqual('>');
+		expect(match[5]).toEqual('111');
+	});
+
+	// Both numbers are implied when absent: an omitted count is 1, and an
+	// omitted drop list means the whole count lands on a single square. The
+	// caller fills those in, so the pattern only has to allow them through.
+	it('leaves the count and the drop list optional', () => {
+		const oneDropped = matchPTNMovement('a1+');
+		expect(oneDropped).not.toEqual(null);
+		expect(oneDropped[1]).toEqual('');
+		expect(oneDropped[5]).toEqual('');
+
+		const threeDropped = matchPTNMovement('3a1+');
+		expect(threeDropped).not.toEqual(null);
+		expect(threeDropped[1]).toEqual('3');
+		expect(threeDropped[5]).toEqual('');
+	});
+
+	it('rejects a drop of zero, which would move no pieces', () => {
+		expect(matchPTNMovement('a1>0')).toEqual(null);
+		expect(matchPTNMovement('3c3>101')).toEqual(null);
+		expect(matchPTNMovement('2d4-20')).toEqual(null);
+	});
+
+	it('rejects rank 0, which would index off the front of the grid', () => {
+		expect(matchPTNMovement('a0+')).toEqual(null);
+		expect(matchPTNMovement('3c0>111')).toEqual(null);
+	});
+
+	it('rejects a placement, so callers fall through to the placement pattern', () => {
+		expect(matchPTNMovement('a1')).toEqual(null);
+		expect(matchPTNMovement('Sc3')).toEqual(null);
+	});
+});


### PR DESCRIPTION
Two problems when loading a game from a PTN — via **Load Game**, a `.ptn` file, or a `?load=` link, which all funnel through `load()`.

## The Clock tag was printed into the clocks

```js
$('.player1-time:first').html(parsed.tags.Clock);
$('.player2-time:first').html(parsed.tags.Clock);
```

The Clock tag is a *time control*, not a remaining time, so both players' clocks read `10:0 +20` — and with the fields playtak-api and playtak-games are gaining, `3:0:0 +1n @30 +5:0`.

`parsePTNClock` now reads it into its parts, so the clocks start at the base duration and everything else goes where it belongs:

| Clock tag | base | inc | scales | trigger | bonus | clock shows |
|---|---|---|---|---|---|---|
| `10:0 +20` | 600 | 20 | false | 0 | 0 | `10:00` |
| `3:0:0 +1n` | 10800 | 1 | **true** | 0 | 0 | `180:00` |
| `10:0 +20 @35 +10:0` | 600 | 20 | false | **35** | **600** | `10:00` |
| `3:0:0 +1n @30 +5:0` | 10800 | 1 | true | 30 | 300 | `180:00` |
| `garbage` / absent | — | — | — | — | — | *defaults left alone* |

An unreadable or missing tag returns `null` rather than zeroing the clocks.

## The rules row beneath the players was left empty

`clearNotationMenu()` hides `#variablerules`, and only `initBoard()` repopulates it — which `load()` cannot call, because `initBoard` also clears and recreates the board it is about to load into. So komi, stone counts, increment and extra time were all missing after loading a PTN.

Split that rendering into `renderVariableRules()` and call it from both. `initBoard` behaves as before; `load` now shows the same row a server-started game does.

## A komi bug this surfaced

`load()` assigned the `Komi` tag straight to `gameData.komi`:

```js
gameData.komi = parsed.tags.Komi || 0;
```

But `gameData.komi` is **half-komi** everywhere else — `server.js` assigns the raw field (`+spl[11]`, `+spl[8]`) and every consumer halves it (`main.js:409`, `board.js:2763`, the rules row). The tag holds the whole value, so after loading a PTN the komi was halved for the flat count and halved again on export. Now doubled on the way in.

This was pre-existing, but it had to be fixed here: the rules row added above reads the same field, and would otherwise have displayed komi 2 as +1.

## A zero drop count, in the same family as the rank fix

Follow-on to #68, which corrected the ply rank from `[0-8]` to `[1-8]` in each of the three PTN load sites separately. The drop list in those same patterns still read `\d*`:

```js
/^([1-9]?)([a-h])([1-8])([><+-])(\d*)$/
```

So `a1>0` parsed as a movement that drops no pieces onto a square. Like rank 0, it corrupted the board quietly rather than being rejected at the parse — the ply consumed a stack it never put down. Drops are now `[1-8]`.

The reason #68 had to fix the same range in three places is that both patterns were written inline at each site, so they could drift. They now live in `ptn.js` as `matchPTNPlacement()` and `matchPTNMovement()`, and the three call sites read the same notation.

The drop list stays optional, because both numbers are implied when absent: an omitted count is 1, and an omitted drop list means the whole count lands on a single square. So `a1+` moves one piece to a2, and `3a1+` drops all three there. The caller fills those in (`board.js`: `drops = count === '' ? [1] : [count]`).

The pick-up count keeps its `[1-9]` range. It is also wrong (9 exceeds any board), but for a different reason than zero, and it is left for its own change.

## Tests

`src/js/tests/parse-ptn-clock.test.js` covers each base-duration shape, fixed and scaling increments, the bonus, all parts together, the defaults, and the null cases.

`src/js/tests/parse-ptn-move.test.js` covers both ply patterns: the accepted shapes, the capture groups each call site reads, the optional count and drop list, and the rejections — zero drops, rank 0, off-board squares, and each pattern declining the other's notation so callers fall through correctly.

Suite green — 27 tests across 3 files.

`eslint` reports nothing on any touched file. (The repo currently reports 229 problems overall on `dev`; the 8 warnings in `board.js` are pre-existing and far from these lines.)

## Related

Companion to [playtak-api#41](https://github.com/USTakAssociation/playtak-api/pull/41) and [playtak-games#19](https://github.com/USTakAssociation/playtak-games/pull/19), which make the exported Clock tag carry the increment scaling and the bonus-at-move in the first place. This PR is what makes those readable on the way back in; it is also correct for today's shorter tags.

