### PR TITLE
Replace the PTN Ninja checkbox with a 2D/3D board toggle

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -574,6 +574,65 @@ a.navitem, div.navitem{
 	display: flex;
 }
 
+/* Segmented 2D / 3D board-mode switch at the top of the Board settings pane.
+   Light theme needs a grey trough so the white active button still reads;
+   dark theme matches the sidebar so the trough looks transparent. */
+.board-mode-toggle {
+	display: flex;
+	width: 100%;
+	padding: 3px;
+	gap: 3px;
+	border: 1px solid var(--secondary-border-color);
+	border-radius: 999px;
+	background-color: #d3d3d3;
+}
+.dark-theme .board-mode-toggle {
+	background-color: var(--primary-bg-color);
+}
+
+.board-mode-option {
+	flex: 1 1 0;
+	min-width: 0;
+	height: 28px;
+	padding: 0;
+	border: none;
+	border-radius: 999px;
+	background-color: transparent;
+	color: #8a8a8a;
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 28px;
+	cursor: pointer;
+}
+/* Hovering the active button is a no-op; only the inactive label brightens. */
+.board-mode-option:not(.active):hover {
+	color: #000000;
+}
+.dark-theme .board-mode-option:not(.active):hover {
+	color: #ffffff;
+}
+
+.board-mode-option.active {
+	background-color: #ffffff;
+	color: #000000;
+	box-shadow: 0px 1px 4px rgba(20, 20, 20, 0.06);
+	cursor: default;
+}
+
+.board-mode-credit {
+	margin: 2px 0 16px 0;
+	font-size: 12px;
+	color: #8a8a8a;
+}
+
+/* In 3D mode the toggle is followed straight away by the first checkbox, so the
+   breathing room the credit line provides in 2D mode has to come from here.
+   Written as an attribute selector because a CSS id selector may not start with
+   a digit — "#3d-settings" is a parse error and the whole rule gets dropped. */
+[id="3d-settings"] {
+	margin-top: 16px;
+}
+
 /* || Modals */
 .modal {
 	text-align: center;

--- a/src/index.html
+++ b/src/index.html
@@ -519,46 +519,27 @@
 				<div class="tab-pane fade show active settings-pane" id="board">
 					<form onsubmit="return false;">
 						<div>
-							<div class="margin-top--8">
-								<label>
-									<input id="2d-board-checkbox" type="checkbox" onClick="toggle2DBoard()"/>
-									PTN Ninja Board
-								</label>
+							<h4>Board Settings</h4>
+							<div class="board-mode-toggle" role="group" aria-label="Board mode">
+								<button type="button" id="board-mode-2d" class="board-mode-option" aria-pressed="false" onclick="setBoardMode('2d')">2D</button>
+								<button type="button" id="board-mode-3d" class="board-mode-option" aria-pressed="false" onclick="setBoardMode('3d')">3D</button>
 							</div>
 							<div id="2d-settings" style="display: none;">
-								<h4>PTN Ninja Settings</h4>
+								<p class="board-mode-credit">Powered by <a href="https://ptn.ninja/" target="_blank" rel="noopener noreferrer">ptn.ninja</a></p>
 								<div class="flex flex-column gap--8">
-									<div class="dropdown">
-										<button id="set-2d-theme" class="btn btn-secondary select dropdown-toggle form-control text-left" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-											Select a theme
-										</button>
-										<ul id="2d-theme-options" class="dropdown-menu settings-drop-down">
-										</ul>
+									<div>
+										<label for="set-2d-theme">Theme</label>
+										<div class="dropdown">
+											<button id="set-2d-theme" class="btn btn-secondary select dropdown-toggle form-control text-left" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+												Select a theme
+											</button>
+											<ul id="2d-theme-options" class="dropdown-menu settings-drop-down">
+											</ul>
+										</div>
 									</div>
 									<div>
 										<input type="text" name="2d-custom" id="2d-custom-theme" class="form-control">
 										<button class="btn btn-pill btn-secondary btn-slim margin-top--8" onclick="set2DCustomTheme(); event.preventDefault();">Set Custom</button>
-									</div>
-									<div>
-										<label>
-											<input type="checkbox" name="2d-board-3d" id="2d-3d-toggle" onchange="toggle2DBoard3D(); event.preventDefault();">
-											Toggle 3D board
-										</label>
-									</div>
-									<div id="2d-board-3d-options" class="flex-column gap--16" style="display: none;">
-										<div>
-											<label>
-												<input type="checkbox" name="2d-ortho" id="2d-ortho" onchange="toggle2DOrtho(); event.preventDefault();">
-												Orthographic
-											</label>
-										</div>
-										<div>
-											<label>
-												Perspective <br />
-												<input id="2d-perspective-slider" type="range" value="5" step="1" min="1" max="10" oninput="perspective2DChange(this.value)" onchange="perspective2DChange(this.value)"/>
-												<span id="2d-perspective-display">5</span>
-											</label>
-										</div>
 									</div>
 									<div>
 										<label>
@@ -594,7 +575,6 @@
 							</div>
 						</div>
 						<div id="3d-settings" class="flex flex-column gap--8">
-							<h4>3D Settings</h4>
 							<div>
 								<label>
 									<input id="animations-checkbox" type="checkbox" onChange="toggleAnimations(event)" checked />

--- a/src/index.html
+++ b/src/index.html
@@ -571,6 +571,27 @@
 											Show game header
 										</label>
 									</div>
+									<div>
+										<label>
+											<input type="checkbox" name="2d-board-3d" id="2d-3d-toggle" onchange="toggle2DBoard3D(); event.preventDefault();">
+											Toggle 2.5D board
+										</label>
+									</div>
+									<div id="2d-board-3d-options" class="flex-column gap--16" style="display: none;">
+										<div>
+											<label>
+												<input type="checkbox" name="2d-ortho" id="2d-ortho" onchange="toggle2DOrtho(); event.preventDefault();">
+												Orthographic
+											</label>
+										</div>
+										<div>
+											<label>
+												Perspective <br />
+												<input id="2d-perspective-slider" type="range" value="5" step="1" min="1" max="10" oninput="perspective2DChange(this.value)" onchange="perspective2DChange(this.value)"/>
+												<span id="2d-perspective-display">5</span>
+											</label>
+										</div>
+									</div>
 								</div>
 							</div>
 						</div>

--- a/src/js/2d-board.js
+++ b/src/js/2d-board.js
@@ -28,6 +28,17 @@ async function messageHandler(event){
 	switch (action){
 		case "SET_UI":
 			// check for the key is in the object
+			if(value.hasOwnProperty("board3D")){
+				localStorage.setItem('2d-board-3d', value.board3D);
+				document.getElementById("2d-3d-toggle").checked = value.board3D;
+				const options = document.getElementById('2d-board-3d-options');
+				if(document.getElementById('2d-3d-toggle').checked){
+					options.style.display = 'flex';
+				}
+				else{
+					options.style.display = 'none';
+				}
+			}
 			if(value.hasOwnProperty("animateBoard")){
 				document.getElementById("2d-animations-toggle").checked = value.animateBoard;
 				localStorage.setItem('2d-axis', value.animateBoard);

--- a/src/js/2d-board.js
+++ b/src/js/2d-board.js
@@ -28,17 +28,6 @@ async function messageHandler(event){
 	switch (action){
 		case "SET_UI":
 			// check for the key is in the object
-			if(value.hasOwnProperty("board3D")){
-				localStorage.setItem('2d-board-3d', value.board3D);
-				document.getElementById("2d-3d-toggle").checked = value.board3D;
-				const options = document.getElementById('2d-board-3d-options');
-				if(document.getElementById('2d-3d-toggle').checked){
-					options.style.display = 'flex';
-				}
-				else{
-					options.style.display = 'none';
-				}
-			}
 			if(value.hasOwnProperty("animateBoard")){
 				document.getElementById("2d-animations-toggle").checked = value.animateBoard;
 				localStorage.setItem('2d-axis', value.animateBoard);

--- a/src/js/game-interface.js
+++ b/src/js/game-interface.js
@@ -137,9 +137,14 @@ function renderVariableRules(){
 		document.getElementById("time-increment").style.display = 'block';
 		const $incrementRule = $("#time-increment-rule");
 		$incrementRule.css('display', 'block');
-		$incrementRule.html(`+${minuteseconds(gameData.increment)}${gameData.incrementScales ? '&times;n' : ''}`);
+		// A scaling increment reads as "+n" / "+2n", matching the create-game
+		// dropdown and the seek/watch tables; a fixed one keeps the clock format.
+		$incrementRule.html(gameData.incrementScales
+			? `+${scalingIncrementLabel(gameData.increment)}`
+			: `+${minuteseconds(gameData.increment)}`);
+		const inc = Number(gameData.increment);
 		const tooltipText = gameData.incrementScales
-			? `Time increment - +${gameData.increment} seconds added each move, scaled by move number`
+			? `Time increment - n is the current move number, so the increment grows each move: move 1 = +${inc}s, move 2 = +${inc * 2}s, move 3 = +${inc * 3}s…`
 			: 'Time increment - Extra time added each move';
 		// If Bootstrap has already initialized a tooltip on this node, it has
 		// moved the original title to `data-original-title` and stripped the
@@ -353,7 +358,7 @@ function loadCurrentGameState(){
 	// clearNotationMenu() blanks and hides the rules row, and the stored PTN has
 	// no Clock tag to rebuild it from — but gameData still holds the time control
 	// from Game Start, so repaint from there. Without this, toggling the board
-	// mode mid-game dropped the increment ("+:01×n") and extra-time rules.
+	// mode mid-game dropped the increment ("+n") and extra-time rules.
 	renderVariableRules();
 	initCounters(0);
 	if(is2DBoard){
@@ -879,6 +884,14 @@ function openingCodeFromName(name){
 	return i < 0 ? 0 : i;
 }
 
+// A scaling increment written the way the create-game dropdown labels it and
+// the seek/watch tables render it: "n" for 1, "2n" for 2. Shared so the rules
+// row beneath the players can't drift from those.
+function scalingIncrementLabel(increment){
+	const inc = Number(increment);
+	return inc === 1 ? "n" : inc + "n";
+}
+
 // Time-control display for the seek/watch tables and the playtak-games table.
 // "10 + 20" = 10 min base with a 20 s increment; "10 min" when there's no
 // increment. With increment scaling the increment is shown as n (the move
@@ -887,7 +900,7 @@ function formatTimeControl(timeSeconds, increment, incrementScales){
 	const mins = timeSeconds / 60;
 	const inc = Number(increment);
 	if(inc > 0){
-		const incText = incrementScales ? (inc === 1 ? "n" : inc + "n") : inc;
+		const incText = incrementScales ? scalingIncrementLabel(inc) : inc;
 		return mins + " + " + incText;
 	}
 	return mins + " min";

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -149,6 +149,23 @@ let settingscounter = 0;
 let is2DBoard = false;
 let fson = false;
 
+// Viewport width at or below which a brand-new user gets the 2D board by default.
+const MOBILE_BOARD_BREAKPOINT = 990;
+
+// Which board to show. An explicit choice always wins; only users who have never
+// picked a side fall through to the viewport-based default. The default is
+// deliberately not persisted, so resizing the window never silently locks it in.
+function prefers2DBoard() {
+	const stored = localStorage.getItem("2d_board");
+	if (stored === "true") {
+		return true;
+	}
+	if (stored === "false") {
+		return false;
+	}
+	return window.innerWidth <= MOBILE_BOARD_BREAKPOINT;
+}
+
 function alert(type, msg) {
 	$("#alert-text").text(msg);
 	const $alert = $("#alert");
@@ -228,11 +245,10 @@ function init() {
 	} else {
 		ninjaElement.src = "https://ptn.ninja/" + ninjaParams;
 	}
-	if (localStorage.getItem("2d_board") === "true") {
+	if (prefers2DBoard()) {
 		document.getElementById("ninja-wrapper").style.display = "block";
 		document.getElementById("3d-settings").style.display = "none";
 		document.getElementById("2d-settings").style.display = "block";
-		document.getElementById("2d-board-checkbox").checked = true;
 		is2DBoard = true;
 		init2DBoard();
 	} else {
@@ -240,6 +256,7 @@ function init() {
 		load3DSettings();
 		init3DBoard();
 	}
+	updateBoardModeButtons();
 	storeNotation();
 }
 
@@ -792,7 +809,7 @@ function filterTable(category) {
 }
 
 $(document).ready(function () {
-	if (localStorage.getItem("2d_board") === "true") {
+	if (prefers2DBoard()) {
 		is2DBoard = true;
 	}
 	if (localStorage.getItem("sound") === "false") {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -136,7 +136,20 @@ const gamePresets = {
 	}
 };
 
-let ismobile = false;
+// Evaluated at load rather than inside init(): prefers2DBoard() reads ismobile
+// from $(document).ready, which runs before init() does. Leaving it unset until
+// init() would make the two prefers2DBoard() call sites disagree.
+function isMobileUserAgent() {
+	const ua = navigator.userAgent.toLowerCase();
+	return (
+		ua.indexOf("android") > -1 ||
+		ua.indexOf("iphone") > -1 ||
+		ua.indexOf("ipod") > -1 ||
+		ua.indexOf("ipad") > -1
+	);
+}
+
+let ismobile = isMobileUserAgent();
 let isidevice = false;
 let fixedcamera = false;
 let clickthrough = true;
@@ -149,12 +162,9 @@ let settingscounter = 0;
 let is2DBoard = false;
 let fson = false;
 
-// Viewport width at or below which a brand-new user gets the 2D board by default.
-const MOBILE_BOARD_BREAKPOINT = 990;
-
 // Which board to show. An explicit choice always wins; only users who have never
-// picked a side fall through to the viewport-based default. The default is
-// deliberately not persisted, so resizing the window never silently locks it in.
+// picked a side fall through to the mobile default. The default is deliberately
+// not persisted, so it never silently locks a mode in.
 function prefers2DBoard() {
 	const stored = localStorage.getItem("2d_board");
 	if (stored === "true") {
@@ -163,7 +173,7 @@ function prefers2DBoard() {
 	if (stored === "false") {
 		return false;
 	}
-	return window.innerWidth <= MOBILE_BOARD_BREAKPOINT;
+	return ismobile;
 }
 
 function alert(type, msg) {
@@ -189,15 +199,9 @@ function togglefs() {
 }
 
 function init() {
+	// ismobile is already set at load; isidevice stays here because it attaches
+	// gesture handlers to document.body.
 	const ua = navigator.userAgent.toLowerCase();
-	if (
-		ua.indexOf("android") > -1 ||
-		ua.indexOf("iphone") > -1 ||
-		ua.indexOf("ipod") > -1 ||
-		ua.indexOf("ipad") > -1
-	) {
-		ismobile = true;
-	}
 	if (
 		ua.indexOf("iphone") > -1 ||
 		ua.indexOf("ipod") > -1 ||

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -19,6 +19,9 @@ const default2DThemes = [
 	{ id: "zen", name: "Zen"}
 ];
 
+// Theme the 2D board starts on when the user has never picked one.
+const DEFAULT_2D_THEME = "aaron";
+
 // sound controls
 function turnsoundon(){
 	const movesound = document.getElementById("move-sound");
@@ -510,13 +513,36 @@ function sliderScale(scaleIn,lazy){
 	}
 }
 
-function toggle2DBoard(){
+// Reflect the current board mode on the 2D/3D segmented switch.
+function updateBoardModeButtons(){
+	const buttons = {
+		'2d': document.getElementById('board-mode-2d'),
+		'3d': document.getElementById('board-mode-3d')
+	};
+	const active = is2DBoard ? '2d' : '3d';
+	for(const mode in buttons){
+		const button = buttons[mode];
+		if(!button){
+			continue;
+		}
+		button.classList.toggle('active', mode === active);
+		button.setAttribute('aria-pressed', mode === active ? 'true' : 'false');
+	}
+}
+
+function setBoardMode(mode){
+	const want2D = mode === '2d';
+	// Clicking the already-active button must not tear down and rebuild the board.
+	if(want2D === is2DBoard){
+		return;
+	}
 	isSwitchingBoardMode = true;
 	removeBoardMessageHandler();
 	removeEventListeners();
-	if(document.getElementById('2d-board-checkbox').checked){
+	if(want2D){
 		localStorage.setItem('2d_board','true');
 		is2DBoard = true;
+		updateBoardModeButtons();
 		// hide the 3d board and show the 2d board
 		document.getElementById("gamecanvas").style.display = "none";
 		document.getElementById("ninja-wrapper").style.display = "block";
@@ -531,6 +557,7 @@ function toggle2DBoard(){
 		document.getElementById("3d-settings").style.display = "flex";
 		localStorage.setItem('2d_board','false');
 		is2DBoard = false;
+		updateBoardModeButtons();
 		document.getElementById("ninja-wrapper").style.display = "none";
 		document.getElementById("gamecanvas").style.display = "block";
 		makeStyleSelector();
@@ -565,6 +592,7 @@ function set2DTheme(theme){
 	const themeObject = default2DThemes.find(t => t.id === theme);
 	if(!themeObject){
 		alert('danger', 'Theme not found: ' + theme);
+		return;
 	}
 	document.getElementById('set-2d-theme').innerText = themeObject.name;
 	document.getElementById(theme).classList.add('active');
@@ -590,32 +618,6 @@ function set2DCustomTheme(){
 	document.getElementById('set-2d-theme').innerText = 'Custom Theme Set';
 	localStorage.setItem('2d-custom-theme', customTheme);
 	set2DUI({theme: JSON.parse(customTheme)});
-}
-
-function toggle2DBoard3D(){
-	localStorage.setItem('2d-board-3d', document.getElementById('2d-3d-toggle').checked);
-	set2DUI({
-		board3D: document.getElementById('2d-3d-toggle').checked
-	});
-	const options = document.getElementById('2d-board-3d-options');
-	if(document.getElementById('2d-3d-toggle').checked){
-		options.style.display = 'flex';
-	}
-	else{
-		options.style.display = 'none';
-	}
-}
-
-function toggle2DOrtho(){
-	const value = document.getElementById('2d-ortho').checked;
-	localStorage.setItem('2d-ortho', value);
-	set2DUI({ orthographic: value});
-}
-
-function perspective2DChange(value){
-	document.getElementById('2d-perspective-display').innerText = value;
-	localStorage.setItem('2d-perspective', value);
-	set2DUI({ perspective: value });
 }
 
 function toggle2DAnimations(){
@@ -691,44 +693,20 @@ function load2DSettings(){
 		document.getElementById('2d-custom-theme').value = localStorage.getItem("2d-custom-theme");
 		set2DUI({theme: JSON.parse(localStorage.getItem("2d-custom-theme"))});
 	}
-	else if(localStorage.getItem('2d-theme')){
-		let theme = default2DThemes.find(t => t.id === localStorage.getItem("2d-custom-theme"));
-		if(!theme){
-			// if not found, set to default theme
-			theme = default2DThemes[7];
-		}
-		document.getElementById('set-2d-theme').innerText = theme.name;
-		set2DTheme(localStorage.getItem('2d-theme'));
+	else{
+		// Fall back to the default theme when nothing is saved, or when a saved id
+		// is no longer one we offer. set2DTheme handles the label, the active
+		// highlight in the dropdown and persisting the choice.
+		const saved = localStorage.getItem('2d-theme');
+		set2DTheme(default2DThemes.some(t => t.id === saved) ? saved : DEFAULT_2D_THEME);
 	}
 
-	if(localStorage.getItem('2d-board-3d')){
-		const value = localStorage.getItem('2d-board-3d') === 'true' ? true : false;
-		document.getElementById('2d-3d-toggle').checked = value;
-		set2DUI({
-			board3D: value
-		});
-		const options = document.getElementById('2d-board-3d-options');
-		if(value){
-			options.style.display = 'flex';
-		}
-		else{
-			options.style.display = 'none';
-		}
-	}
-
-	if(localStorage.getItem('2d-ortho')){
-		const value = localStorage.getItem('2d-ortho') === 'true' ? true : false;
-		document.getElementById('2d-ortho').checked = value;
-		set2DUI({
-			orthographic: value
-		});
-	}
-
-	if(localStorage.getItem('2d-perspective')){
-		document.getElementById("2d-perspective-slider").value = localStorage.getItem('2d-perspective');
-		document.getElementById('2d-perspective-display').innerText = localStorage.getItem('2d-perspective');
-		set2DUI({ perspective: localStorage.getItem('2d-perspective') });
-	}
+	// PTN Ninja's own 3D rendering is no longer exposed in the sidebar; keep the
+	// embed flat regardless of any preference saved before the control was removed.
+	set2DUI({ board3D: false });
+	localStorage.removeItem('2d-board-3d');
+	localStorage.removeItem('2d-ortho');
+	localStorage.removeItem('2d-perspective');
 
 	if(localStorage.getItem('2d-animations')){
 		const value = localStorage.getItem('2d-animations') === 'true' ? true : false;

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -620,6 +620,34 @@ function set2DCustomTheme(){
 	set2DUI({theme: JSON.parse(customTheme)});
 }
 
+// PTN Ninja's "2.5D" board: the flat board drawn with perspective. Named to
+// keep it distinct from the fully 3D board the 3D mode renders.
+function toggle2DBoard3D(){
+	localStorage.setItem('2d-board-3d', document.getElementById('2d-3d-toggle').checked);
+	set2DUI({
+		board3D: document.getElementById('2d-3d-toggle').checked
+	});
+	const options = document.getElementById('2d-board-3d-options');
+	if(document.getElementById('2d-3d-toggle').checked){
+		options.style.display = 'flex';
+	}
+	else{
+		options.style.display = 'none';
+	}
+}
+
+function toggle2DOrtho(){
+	const value = document.getElementById('2d-ortho').checked;
+	localStorage.setItem('2d-ortho', value);
+	set2DUI({ orthographic: value});
+}
+
+function perspective2DChange(value){
+	document.getElementById('2d-perspective-display').innerText = value;
+	localStorage.setItem('2d-perspective', value);
+	set2DUI({ perspective: value });
+}
+
 function toggle2DAnimations(){
 	const checked = document.getElementById('2d-animations-toggle').checked;
 	localStorage.setItem('2d-animations', checked);
@@ -701,12 +729,34 @@ function load2DSettings(){
 		set2DTheme(default2DThemes.some(t => t.id === saved) ? saved : DEFAULT_2D_THEME);
 	}
 
-	// PTN Ninja's own 3D rendering is no longer exposed in the sidebar; keep the
-	// embed flat regardless of any preference saved before the control was removed.
-	set2DUI({ board3D: false });
-	localStorage.removeItem('2d-board-3d');
-	localStorage.removeItem('2d-ortho');
-	localStorage.removeItem('2d-perspective');
+	if(localStorage.getItem('2d-board-3d')){
+		const value = localStorage.getItem('2d-board-3d') === 'true' ? true : false;
+		document.getElementById('2d-3d-toggle').checked = value;
+		set2DUI({
+			board3D: value
+		});
+		const options = document.getElementById('2d-board-3d-options');
+		if(value){
+			options.style.display = 'flex';
+		}
+		else{
+			options.style.display = 'none';
+		}
+	}
+
+	if(localStorage.getItem('2d-ortho')){
+		const value = localStorage.getItem('2d-ortho') === 'true' ? true : false;
+		document.getElementById('2d-ortho').checked = value;
+		set2DUI({
+			orthographic: value
+		});
+	}
+
+	if(localStorage.getItem('2d-perspective')){
+		document.getElementById("2d-perspective-slider").value = localStorage.getItem('2d-perspective');
+		document.getElementById('2d-perspective-display').innerText = localStorage.getItem('2d-perspective');
+		set2DUI({ perspective: localStorage.getItem('2d-perspective') });
+	}
 
 	if(localStorage.getItem('2d-animations')){
 		const value = localStorage.getItem('2d-animations') === 'true' ? true : false;


### PR DESCRIPTION
## What

Replaces the "PTN Ninja Board" checkbox in the settings sidebar with a two-button 2D/3D segmented toggle under a single **Board Settings** header.

- **2D/3D toggle group.** Active button is a white pill with a subtle drop shadow; the inactive label brightens on hover. Spans the full sidebar width with both halves exactly equal. Styled for light and dark themes.
- **Removed the redundant headers** ("PTN Ninja Settings" / "3D Settings"), now covered by "Board Settings".
- **Credits ptn.ninja** beneath the toggle in 2D mode, linking to https://ptn.ninja/.
- **Labelled the 2D theme dropdown** "Theme".
- **Re-labeled the "Toggle 3D board" checkbox to "Toggle 2.5D board"**, to avoid confusion with the regular "3D" board
- **A scaling increment now reads as `+n` in the sidebar.** It previously showed
`+:01×n`, a format used nowhere else. The create-game dropdown labels these `n` and `2n`, and the seek
and watch tables render `10 + n`. The rules row now shows `+n` / `+2n` to match
- **New users default to the 2D board on mobile**, reading the client's existing `ismobile` flag. An explicit choice always wins, and the default is deliberately not persisted, so we never write a preference the user didn't actually pick.
- **The 2D board defaults to the Aaron theme** when none is saved (to parallel the "Aaron-style" default 3D board). Previously no theme was sent at all, leaving the embed on whatever PTN Ninja picked.

<img width="1072" height="831" alt="PlayTakBoard2D3DToggle" src="https://github.com/user-attachments/assets/662a5270-f27e-4b8d-ba1f-9827e8ecc260" />

## Incidental fixes

- `load2DSettings` looked up the saved theme under the `2d-custom-theme` key instead of `2d-theme`, so the lookup always failed and the dropdown label flashed `default2DThemes[7]` ("Classic") before `set2DTheme` corrected it.
- `set2DTheme` alerted "Theme not found" and then fell through to `themeObject.name`, throwing on the undefined it had just reported.

## Note for reviewers

The margin rule targeting `#3d-settings` is written as `[id="3d-settings"]`. **A CSS id selector may not begin with a digit** — `#3d-settings` is a parse error and the browser drops the entire rule with no console warning. The same applies to `querySelector`. Every `2d-*`/`3d-*` id in this repo is reachable only via `getElementById`.

## Testing

- Toggle styling verified in both themes; halves measured at exactly equal width, filling the pane.
- Clicking the active button is a no-op and doesn't write to `localStorage`.
- Board default: mobile UA → 2D, desktop → 3D; a stored `2d_board` still wins either way. Confirmed both `prefers2DBoard()` call sites agree, so mobile connects to the server once, not twice.
- 2.5D board and its Orthographic/Perspective controls confirmed via PTN Ninja's `postMessage` echoes, and all three restore after reload.
- Rules row shows `+n` / `+2n` for scaling increments, `+:10` for fixed; tables and dropdown unchanged.
- Theme defaults to Aaron when unset; a saved theme is respected.
- `npm test` 35/35, no new lint findings.

To test the new-user default, clear the key and reload:

```js
localStorage.removeItem("2d_board"); location.reload()
