### PR TITLE
fix(landing): follow the dark theme on the landing page

### DIFF
--- a/src/css/landing.css
+++ b/src/css/landing.css
@@ -16,6 +16,36 @@
 	overflow-x: hidden;
 }
 
+/* Dark theme
+   The .landing block above re-declares the palette, so the values set on
+   body.dark-theme in main.css never reach anything inside the landing page.
+   Re-declare them here at higher specificity. --secondary-font-color stays
+   white: it labels the parallax heading and the navy .btn-primary. */
+.dark-theme .landing {
+	--primary-color: #7ea2f0;
+	--primary-bg-color: #191f25;
+	--secondary-bg-color: #2f2e2e;
+	--primary-font-color: #c8c8c8;
+}
+
+/* Wordmark and stack art are pure #000/#fff, so a straight invert is correct. */
+.dark-theme .landing .playtak-logo svg {
+	filter: invert(1);
+}
+
+/* board-top.svg / board-bottom.svg fade to white to meet a white page.
+   Multiplying against the page background sinks that fade into the dark
+   background instead of leaving a white band. */
+.dark-theme .landing .header,
+.dark-theme .landing .footer {
+	background-blend-mode: multiply;
+}
+
+/* The light half of the parallax scrim has to darken with the page. */
+.dark-theme .landing .parallax {
+	--parallax-scrim: rgb(25 31 37 / 55%);
+}
+
 .landing .landing-wrapper {
 	width: 100vw;
 	height: 100vh;
@@ -76,7 +106,8 @@
 }
 
 .landing .parallax {
-	background-image: linear-gradient(0deg, rgb(53 68 136), rgb(255 255 255 / 30%)), url('../images/parallax.jpg');
+	--parallax-scrim: rgb(255 255 255 / 30%);
+	background-image: linear-gradient(0deg, rgb(53 68 136), var(--parallax-scrim)), url('../images/parallax.jpg');
 	background-position: center;
 	background-attachment: fixed;
 	background-repeat: no-repeat;
@@ -90,6 +121,10 @@
 
 .landing .heading-text a{
 	color: var(--secondary-font-color);
+}
+
+.landing .heading-text svg {
+	fill: var(--secondary-font-color);
 }
 
 .landing .heading-text a span {
@@ -135,7 +170,7 @@
 
 .landing .footer-banner{
 	height: 50px;
-	background-color: var(--primary-color);
+	background-color: var(--secondary-color);
 }
 
 /* utilities */


### PR DESCRIPTION
The landing page stayed light with dark mode on.

`.landing` re-declares the palette custom properties (`--primary-bg-color`, `--primary-font-color`, …) inside its own scope, so the values set on `body.dark-theme` in `main.css` never reached anything inside it.

## Changes

- `.dark-theme .landing` re-declares the same properties at higher specificity. `--secondary-font-color` deliberately stays white — it colors the parallax heading and the label on the navy `.btn-primary`, neither of which follows the page background.
- `.landing .footer-banner` now reads `--secondary-color` instead of `--primary-color`. Same value (`#35478C`) in light mode, so nothing changes there; it decouples the navy banner from the link color, which has to lighten in dark mode to stay legible.
- `.landing .heading-text svg` reads `--secondary-font-color` instead of inheriting `--primary-bg-color` from `.landing svg`. Those icons sit on a photo, not on the page background. Identical in light mode (both `#ffffff`).
- `background-blend-mode: multiply` on the dark header/footer. `board-top.svg` and `board-bottom.svg` have a white-to-transparent fade baked in to meet a white page; multiplying against the page background sinks that fade into the dark background instead of leaving a white band.
- `filter: invert(1)` on the dark wordmark. The logo is pure `#000`/`#fff`, so a straight invert is correct.
- The parallax scrim moves behind a `--parallax-scrim` custom property so the dark override sets one color instead of restating the whole `background-image`, image path included. Same rendered value in light mode.

CSS only. No markup, no JS, no new assets.

## How to verify manually

```
npm install        # or pnpm install
npm run dev        # serves ./src on :3000
```

1. Open the app, click the gear icon, enable **Dark Mode**.
2. Reload so the landing page shows (or clear `disable-landing` from localStorage).
3. Check top to bottom:
   - header background is dark, no white band above the parallax strip
   - "PLAY TAK" wordmark and stack art read light-on-dark
   - the graduation-cap and arrow icons on "LEARN TO PLAY TAK" stay white
   - "Upcoming Events" section and table rules are dark
   - footer is dark; the navy banner strip at the very bottom is unchanged
   - "Play as Guest" / "U.S. Tak Association" links are light blue, not navy
4. Click **Log In** and **Sign Up** — inputs and buttons should be dark and readable.
5. Turn Dark Mode back off and confirm the landing page is pixel-identical to before this branch.

Also worth checking with no stored preference and the OS set to dark: `loadInterfaceSettings()` falls back to `prefers-color-scheme`, so the landing page should come up dark on first visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cda1DrnVfNH6V1Rd6Q6edD
