### PR TITLE
fix(game): keep the clocks on screen when the notation is collapsed

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -259,18 +259,30 @@ a.navitem, div.navitem{
 	top: 35px;
 	z-index: 10;
 	bottom: 0;
+	left: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	/* #floating spans the full height so the clocks can sit at its top and
+	   bottom edges. Only its children may take pointer events, or the empty
+	   middle swallows board input while the notation is collapsed. */
+	pointer-events: none;
+}
+
+#floating > * {
+	pointer-events: auto;
 }
 
 #rmenu {
 	border: 1px solid var(--primary-border-color);
+	border-top: none;
+	border-bottom: none;
 	width: 200px;
+	flex: 1;
+	min-height: 0;
 	text-align: left;
 	overflow: hidden;
 	background-color: var(--secondary-bg-color);
-	top: 0;
-	bottom: 0;
-	left: 0;
-	position: absolute;
 }
 
 .section-title{
@@ -279,6 +291,8 @@ a.navitem, div.navitem{
 
 .player-box{
 	padding: 0px;
+	background-color: var(--secondary-bg-color);
+	border: 1px solid var(--primary-border-color);
 }
 
 .rulebox{

--- a/src/index.html
+++ b/src/index.html
@@ -254,31 +254,31 @@
 				</svg>
 			</div>
 
-			<div id="rmenu" class="flex flex-column">
-				<div class="center player-box">
-					<div id="player-opp">
-						<div class="flex flex-center flex-align-center gap--8">
-							<svg
-								id="player-opp-img"
-								class="playerimg iswhite"
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 0 448 512"
-							>
-								<defs>
-									<path
-										id="head"
-										d="M224 256c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z"
-									></path>
-									<clippath id="insidehead"><use xlink:href="#head"></use></clippath>
-								</defs>
-								<use xlink:href="#head" clip-path="url(#insidehead)"></use>
-							</svg>
-							<div id="player-opp-time" class="player1-time">00.<span style="font-size: 70%">0</span></div>
-						</div>
-						<div id="player-opp-name" class="player1-name">You</div>
+			<div class="center player-box">
+				<div id="player-opp">
+					<div class="flex flex-center flex-align-center gap--8">
+						<svg
+							id="player-opp-img"
+							class="playerimg iswhite"
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 448 512"
+						>
+							<defs>
+								<path
+									id="head"
+									d="M224 256c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z"
+								></path>
+								<clippath id="insidehead"><use xlink:href="#head"></use></clippath>
+							</defs>
+							<use xlink:href="#head" clip-path="url(#insidehead)"></use>
+						</svg>
+						<div id="player-opp-time" class="player1-time">00.<span style="font-size: 70%">0</span></div>
 					</div>
+					<div id="player-opp-name" class="player1-name">You</div>
 				</div>
+			</div>
 
+			<div id="rmenu" class="flex flex-column">
 				<div id="variablerules" class="flex flex-center flex-align-center">
 					<span
 						id="komirule"
@@ -412,28 +412,28 @@
 						</svg>
 					</button>
 				</div>
+			</div>
 
-				<div class="center player-box">
-					<div id="player-me">
-						<div class="flex flex-center flex-align-center gap--8">
-							<svg
-								id="player-me-img"
-								class="playerimg isblack"
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 0 448 512"
-							>
-								<defs>
-									<path
-										d="M224 256c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z"
-									></path>
-									<clippath><use xlink:href="#head"></use></clippath>
-								</defs>
-								<use xlink:href="#head" clip-path="url(#insidehead)"></use>
-							</svg>
-							<div id="player-me-time" class="player2-time">00.<span style="font-size: 70%">0</span></div>
-						</div>
-						<div id="player-me-name" class="player2-name">You</div>
+			<div class="center player-box">
+				<div id="player-me">
+					<div class="flex flex-center flex-align-center gap--8">
+						<svg
+							id="player-me-img"
+							class="playerimg isblack"
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 448 512"
+						>
+							<defs>
+								<path
+									d="M224 256c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z"
+								></path>
+								<clippath><use xlink:href="#head"></use></clippath>
+							</defs>
+							<use xlink:href="#head" clip-path="url(#insidehead)"></use>
+						</svg>
+						<div id="player-me-time" class="player2-time">00.<span style="font-size: 70%">0</span></div>
 					</div>
+					<div id="player-me-name" class="player2-name">You</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Collapsing the notation panel also removed both clocks, and on mobile there was no clock at all.

The two `.player-box` elements were nested inside `#rmenu`, so the "show/hide notation" toggle took them with it. `adjustsidemenu()` defaults that toggle to hidden below 600px, so a phone never showed a clock unless the user opened the notation panel over the board.

The clocks aren't part of the notation, so they move out to be siblings of `#rmenu` inside `#floating`.

## Changes

`src/index.html` — pure move. The opponent box moves above `#rmenu`, the player box below it; content is byte-identical apart from one level of dedent.

`src/css/main.css`
- `#floating` becomes the flex column that owns the layout: `left: 0`, `flex-direction: column`, `justify-content: space-between`. With `width: auto` it shrink-wraps, so it is 200px wide while `#rmenu` is visible and collapses to the clock width when it isn't.
- `#floating` gets `pointer-events: none`, with `#floating > *` restoring `auto`. It previously had no in-flow children (both `#rmenu` and the toggle were absolutely positioned), so it computed to zero width and never intercepted anything. Now that it is a real column pinned `top: 35px` to `bottom: 0`, the empty gap between the two clock boxes would otherwise swallow board input down the left edge whenever the notation is collapsed.
- `#rmenu` drops `position: absolute` and its offsets, and takes `flex: 1; min-height: 0` so `#notationbar` keeps scrolling. `border-top`/`border-bottom` are dropped because the player boxes now carry those edges — no doubled seam.
- `.player-box` picks up the background and border it used to inherit from `#rmenu`.

No JS changes. `#player-me-time` / `#player-opp-time` keep their ids and the `player1-time` / `player2-time` class swapping in `server.js` and `game-interface.js` is untouched, so there is still exactly one clock element per player and the `:first` selectors stay correct.

## How to verify manually

```
npm install        # or pnpm install
npm run dev        # serves ./src on :3000
```

Get into a game (observe one from **Watch**, or start a scratch game and fake it from the console):

```js
hideElement('landing');
$('.player1-time:first').html('12:34');
$('.player2-time:first').html('05:02');
```

**Desktop, notation open** — the left panel should look exactly as it does today: opponent clock at top, rules and action icons, move list, playback buttons, your clock pinned to the bottom.

**Desktop, notation collapsed** — click the `>` arrow on the left edge. The move list and action buttons go away; both clocks stay, as compact panels in the top-left and bottom-left corners. Click again to restore.

**Mobile** — open at a viewport under 600px wide with `shownotationv` / `shownotationh` cleared from localStorage, so the notation starts collapsed. Both clocks should be on screen without opening the panel. Each box is ~109px wide and sits in a corner, so the board is not obscured.

**Board input under the collapsed panel** — with the notation collapsed, drag to rotate the 3D board starting from the empty left edge, between the two clock boxes. It should rotate. In the console, `document.elementFromPoint(50, 400)` should report `gamecanvas`, not `floating`.

**Both board modes** — repeat the collapse/restore with the 2D board enabled in settings. `set2DBoardPadding()` reads `rmenu.clientWidth`, which still reports 198 open / 0 collapsed, so `#ninja` padding should be unchanged.

**Long games** — load a game with 100+ plies. The move list should scroll inside `#notationbar` with the playback buttons pinned below it, rather than pushing them past the bottom of the panel (this is what `min-height: 0` on `#rmenu` buys).

Worth a look while you're in there: the active-player highlight and the `hurrytime` red state should still land on the right box after colors swap.

`npx vitest run` → 35 passing, unchanged. Lint is unchanged from `dev` (210 pre-existing errors, 24 warnings, all formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cda1DrnVfNH6V1Rd6Q6edD
