### PR TITLE
fix: last move highlight setting toggle to send real board square object

### DIFF
--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -177,7 +177,8 @@ function showLastMoveHighlighter(event){
 	else{
 		// Re-highlight the last moved square when turning on
 		if(board.lastMovedSquareList.length > 0){
-			board.highlightLastMove_sq(board.lastMovedSquareList.at(-1));
+			const coords = board.lastMovedSquareList.at(-1);
+			board.highlightLastMove_sq(board.get_board_obj(coords.file, coords.rank), gameData.move_count - 1);
 		}
 	}
 }


### PR DESCRIPTION
Resolves https://app.clickup.com/t/31057087/868kngrhv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed last-move highlighting when the highlighter is turned back on, ensuring the correct board square is highlighted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->