### PR TITLE
Refactor Icons

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -84,8 +84,8 @@ h4 {
 	height: 15px;
 }
 .action-icon{
-	height: 20px;
-	width: 20px;
+	height: 24px;
+	width: 24px;
 	vertical-align: middle;
 }
 #gamecanvas{
@@ -147,15 +147,10 @@ header{
 	vertical-align: middle;
 }
 
-.navitem svg{
+/* .navitem svg{
 	fill: var(--primary-fill-color);
 	stroke: var(--primary-stroke-color);
-}
-
-.nav-link:hover svg{
-	fill: var(--primary-fill-color);
-	stroke: var(--primary-stroke-color);
-}
+} */
 
 nav button {
 	display: flex;
@@ -171,11 +166,14 @@ a.navitem, div.navitem{
 	color: var(--primary-font-color);
 }
 
-.navicon{
+.navicon {
 	height: 16px;
 	width: 16px;
 }
-
+.navicon-20 {
+	height: 20px;
+	width: 20px;
+}
 .usta-nav {
 	width: 25px;
 	height: 25px;
@@ -369,8 +367,8 @@ a.navitem, div.navitem{
 
 /* Player styles */
 .playerimg{
-	height: 20px;
-	width: 20px;
+	height: 24px;
+	width: 24px;
 }
 
 #player-opp-img.iswhite, #player-me-img.iswhite {
@@ -465,11 +463,6 @@ a.navitem, div.navitem{
 	font-size: 16px;
 	font-weight: bold;
 	padding: 0;
-}
-
-.chatclose svg {
-	width: 13px;
-	fill: var(--primary-fill-color)
 }
 
 .roombody{
@@ -1288,7 +1281,7 @@ a.btn.btn-primary {
 }
 
 .active .stroke-primary {
-	stroke: var(--dark);
+	stroke: var(--dark-fill-color);
 }
 
 /* || Dark popover — match the dark Bootstrap tooltips (e.g. the increment-scaling help) */

--- a/src/index.html
+++ b/src/index.html
@@ -82,40 +82,55 @@
 					data-placement="bottom"
 					title="Sound is off"
 				>
-					<svg class="action-icon" viewBox="0 0 640 512">
-						<path
-							d="M215.03 71.05L126.06 160H24c-13.26 0-24 10.74-24 24v144c0 13.25 10.74 24 24 24h102.06l88.97 88.95c15.03 15.03 40.97 4.47 40.97-16.97V88.02c0-21.46-25.96-31.98-40.97-16.97zM461.64 256l45.64-45.64c6.3-6.3 6.3-16.52 0-22.82l-22.82-22.82c-6.3-6.3-16.52-6.3-22.82 0L416 210.36l-45.64-45.64c-6.3-6.3-16.52-6.3-22.82 0l-22.82 22.82c-6.3 6.3-6.3 16.52 0 22.82L370.36 256l-45.63 45.63c-6.3 6.3-6.3 16.52 0 22.82l22.82 22.82c6.3 6.3 16.52 6.3 22.82 0L416 301.64l45.64 45.64c6.3 6.3 16.52 6.3 22.82 0l22.82-22.82c6.3-6.3 6.3-16.52 0-22.82L461.64 256z"
-						></path>
+					<!-- MIT Icon https://www.svgrepo.com/svg/378707/sound-off -->
+					<svg class="action-icon" viewBox="0 0 24 24" fill="none">
+						<g fill="none" stroke="var(--primary-stroke-color)">
+							<path d="M22 15L16 9.00001M22 9L16 15" stroke-width="2" stroke-linecap="round"/>
+							<path d="M2 14.9588L2 9.04123C2 8.46617 2.44772 8 3 8H6.58579C6.851 8 7.10536 7.8903 7.29289 7.69503L10.2929 4.30706C10.9229 3.65112 12 4.11568 12 5.04332V18.9567C12 19.8908 10.91 20.3524 10.2839 19.6834L7.29437 16.3145C7.10615 16.1134 6.84791 16 6.57824 16H3C2.44772 16 2 15.5338 2 14.9588Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+						</g>
 					</svg>
 				</button>
 				<button class="navitem" id="soundon" onclick="turnsoundoff()" data-toggle="tooltip" data-placement="bottom" title="Sound is on">
-					<svg class="action-icon" viewBox="0 0 640 512">
-						<path
-							d="M215.03 71.05L126.06 160H24c-13.26 0-24 10.74-24 24v144c0 13.25 10.74 24 24 24h102.06l88.97 88.95c15.03 15.03 40.97 4.47 40.97-16.97V88.02c0-21.46-25.96-31.98-40.97-16.97zm233.32-51.08c-11.17-7.33-26.18-4.24-33.51 6.95-7.34 11.17-4.22 26.18 6.95 33.51 66.27 43.49 105.82 116.6 105.82 195.58 0 78.98-39.55 152.09-105.82 195.58-11.17 7.32-14.29 22.34-6.95 33.5 7.04 10.71 21.93 14.56 33.51 6.95C528.27 439.58 576 351.33 576 256S528.27 72.43 448.35 19.97zM480 256c0-63.53-32.06-121.94-85.77-156.24-11.19-7.14-26.03-3.82-33.12 7.46s-3.78 26.21 7.41 33.36C408.27 165.97 432 209.11 432 256s-23.73 90.03-63.48 115.42c-11.19 7.14-14.5 22.07-7.41 33.36 6.51 10.36 21.12 15.14 33.12 7.46C447.94 377.94 480 319.54 480 256zm-141.77-76.87c-11.58-6.33-26.19-2.16-32.61 9.45-6.39 11.61-2.16 26.2 9.45 32.61C327.98 228.28 336 241.63 336 256c0 14.38-8.02 27.72-20.92 34.81-11.61 6.41-15.84 21-9.45 32.61 6.43 11.66 21.05 15.8 32.61 9.45 28.23-15.55 45.77-45 45.77-76.88s-17.54-61.32-45.78-76.86z"
-						></path>
+					<!-- MIT Icon https://www.svgrepo.com/svg/378708/sound-on -->
+					<svg class="action-icon" viewBox="0 0 24 24" fill="none">
+						<g fill="none" stroke="var(--primary-stroke-color)">
+							<path d="M2 14.9588L2 9.04123C2 8.46617 2.44772 8 3 8H6.58579C6.851 8 7.10536 7.8903 7.29289 7.69503L10.2929 4.30706C10.9229 3.65112 12 4.11568 12 5.04332V18.9567C12 19.8908 10.91 20.3524 10.2839 19.6834L7.29437 16.3145C7.10615 16.1134 6.84791 16 6.57824 16H3C2.44772 16 2 15.5338 2 14.9588Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+							<path d="M16 8.5C17.3333 10.2778 17.3333 13.7222 16 15.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+							<path d="M19 5C22.9879 8.80835 23.0121 15.2171 19 19" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+						</g>
 					</svg>
 				</button>
 				<button class="navitem" onclick="toggleSettingsDrawer(true)" data-toggle="tooltip" data-placement="bottom" title="Open settings menu">
-					<svg class="action-icon" viewBox="0 0 512 512">
-						<path
-							d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
-						></path>
+					<!-- Apache icon https://www.svgrepo.com/svg/340999/settings -->
+					<svg class="action-icon" viewBox="0 0 32 32" id="icon">
+						<g>
+							<path d="M27,16.76c0-.25,0-.5,0-.76s0-.51,0-.77l1.92-1.68A2,2,0,0,0,29.3,11L26.94,7a2,2,0,0,0-1.73-1,2,2,0,0,0-.64.1l-2.43.82a11.35,11.35,0,0,0-1.31-.75l-.51-2.52a2,2,0,0,0-2-1.61H13.64a2,2,0,0,0-2,1.61l-.51,2.52a11.48,11.48,0,0,0-1.32.75L7.43,6.06A2,2,0,0,0,6.79,6,2,2,0,0,0,5.06,7L2.7,11a2,2,0,0,0,.41,2.51L5,15.24c0,.25,0,.5,0,.76s0,.51,0,.77L3.11,18.45A2,2,0,0,0,2.7,21L5.06,25a2,2,0,0,0,1.73,1,2,2,0,0,0,.64-.1l2.43-.82a11.35,11.35,0,0,0,1.31.75l.51,2.52a2,2,0,0,0,2,1.61h4.72a2,2,0,0,0,2-1.61l.51-2.52a11.48,11.48,0,0,0,1.32-.75l2.42.82a2,2,0,0,0,.64.1,2,2,0,0,0,1.73-1L29.3,21a2,2,0,0,0-.41-2.51ZM25.21,24l-3.43-1.16a8.86,8.86,0,0,1-2.71,1.57L18.36,28H13.64l-.71-3.55a9.36,9.36,0,0,1-2.7-1.57L6.79,24,4.43,20l2.72-2.4a8.9,8.9,0,0,1,0-3.13L4.43,12,6.79,8l3.43,1.16a8.86,8.86,0,0,1,2.71-1.57L13.64,4h4.72l.71,3.55a9.36,9.36,0,0,1,2.7,1.57L25.21,8,27.57,12l-2.72,2.4a8.9,8.9,0,0,1,0,3.13L27.57,20Z" transform="translate(0 0)"/>
+							<path d="M16,22a6,6,0,1,1,6-6A5.94,5.94,0,0,1,16,22Zm0-10a3.91,3.91,0,0,0-4,4,3.91,3.91,0,0,0,4,4,3.91,3.91,0,0,0,4-4A3.91,3.91,0,0,0,16,12Z" transform="translate(0 0)"/>
+						</g>
 					</svg>
 				</button>
 				<button id="login-button" class="btn btn-pill btn-primary btn-slim navitemlogin" onclick="server.loginbutton()">
 					Log In
 				</button>
 				<button id="logout-button" class="navitem" onclick="server.loginbutton()" data-toggle="tooltip" data-placement="bottom" title="Log out">
-					<svg class="action-icon" viewBox="0 0 576 512"><path d="M534.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L434.7 224 224 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l210.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128zM192 96c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-53 0-96 43-96 96l0 256c0 53 43 96 96 96l64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l64 0z"/></svg>
+					<!-- PD Icon https://www.svgrepo.com/svg/499618/logout -->
+					<svg class="action-icon" viewBox="0 0 24 24" fill="none">
+						<path fill-rule="evenodd" clip-rule="evenodd" d="M2 6.5C2 4.01472 4.01472 2 6.5 2H12C14.2091 2 16 3.79086 16 6V7C16 7.55228 15.5523 8 15 8C14.4477 8 14 7.55228 14 7V6C14 4.89543 13.1046 4 12 4H6.5C5.11929 4 4 5.11929 4 6.5V17.5C4 18.8807 5.11929 20 6.5 20H12C13.1046 20 14 19.1046 14 18V17C14 16.4477 14.4477 16 15 16C15.5523 16 16 16.4477 16 17V18C16 20.2091 14.2091 22 12 22H6.5C4.01472 22 2 19.9853 2 17.5V6.5ZM18.2929 8.29289C18.6834 7.90237 19.3166 7.90237 19.7071 8.29289L22.7071 11.2929C23.0976 11.6834 23.0976 12.3166 22.7071 12.7071L19.7071 15.7071C19.3166 16.0976 18.6834 16.0976 18.2929 15.7071C17.9024 15.3166 17.9024 14.6834 18.2929 14.2929L19.5858 13L11 13C10.4477 13 10 12.5523 10 12C10 11.4477 10.4477 11 11 11L19.5858 11L18.2929 9.70711C17.9024 9.31658 17.9024 8.68342 18.2929 8.29289Z" />
+					</svg>
 				</button>
 			</div>
 			<div id="menu-toggle" class="flex--20">
 				<button class="btn btn-link menu-button" onclick="toggleMobileMenu()">
 					<div id="mobile-open">
-						<svg viewBox="0 0 448 512" class="fill-primary"><path d="M0 96C0 78.3 14.3 64 32 64H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H416c17.7 0 32 14.3 32 32z"/></svg>
+						<!-- MLP Icon https://www.svgrepo.com/svg/503053/menu -->
+						<svg class="navitem-20" viewBox="0 0 24 24" fill="none">
+							<path fill-rule="evenodd" clip-rule="evenodd" d="M2 7a1 1 0 0 1 1-1h18a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1zm0 5a1 1 0 0 1 1-1h18a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1zm1 4a1 1 0 1 0 0 2h18a1 1 0 1 0 0-2H3z" />
+						</svg>
 					</div>
 					<div id="mobile-close" style="display: none;">
-						<svg viewBox="0 0 320 512" class="fill-primary"><path d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"/></svg>
+						<!-- MLP Icon https://www.svgrepo.com/svg/503004/close -->
+						<svg class="navitem-20" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.207 6.207a1 1 0 0 0-1.414-1.414L12 10.586 6.207 4.793a1 1 0 0 0-1.414 1.414L10.586 12l-5.793 5.793a1 1 0 1 0 1.414 1.414L12 13.414l5.793 5.793a1 1 0 0 0 1.414-1.414L13.414 12l5.793-5.793z"/>
+						</svg>
 					</div>
 				</button>
 			</div>
@@ -123,14 +138,29 @@
 				<ul id="main-nav" class="menu flex">
 					<li>
 						<button class="navitem" onclick="$('#creategamemodal').modal('show'); closeMobileMenu()" data-toggle="tooltip" data-placement="auto" title="Create an online game, a scratch board, or load from PTN/TPS">
-							<svg class="navicon" viewBox="0 0 24 24"><path d="M19 17H22V19H19V22H17V19H14V17H17V14H19V17M8 16H12V12H8V16M12 12H16V8H12V12M2 2V22H13.54C13 21.42 12.63 20.74 12.36 20H8V16H4V12H8V8H4V4H8V8H12V4H16V8H20V12.36C20.74 12.63 21.42 13 22 13.54V2H2Z"></path></svg>
+							<!-- MDI Icon (Apache 2.0) - checkerboard-plus - https://pictogrammers.com/library/mdi/icon/checkerboard-plus/ -->
+							<svg class="navicon" viewBox="0 0 24 24">
+								<path d="M19 17H22V19H19V22H17V19H14V17H17V14H19V17M8 16H12V12H8V16M12 12H16V8H12V12M2 2V22H13.54C13 21.42 12.63 20.74 12.36 20H8V16H4V12H8V8H4V4H8V8H12V4H16V8H20V12.36C20.74 12.63 21.42 13 22 13.54V2H2Z"></path>
+							</svg>
 							New Game
 						</button>
 					</li>
 					<li>
 						<button class="navitem" style="min-width: 124px" onclick="$('#joingame-modal').modal('show'); closeMobileMenu()"
 							data-toggle="tooltip" data-placement="auto" title="Available humans + AIs to play against">
-							<svg class="navicon" viewBox="4 4 26 26"><path d="M28.414,24l-3-3l2.293-2.293l-1.414-1.414l-2.236,2.236l-3.588-4.186L25,11.46V6h-5.46L16,10.13  L12.46,6H7v5.46l4.531,3.884l-3.588,4.186l-2.236-2.236l-1.414,1.414L6.586,21l-3,3L7,27.414l3-3l2.293,2.293l1.414-1.414 l-2.237-2.237L16,19.174l4.53,3.882l-2.237,2.237l1.414,1.414L22,24.414l3,3L28.414,24z M6.414,24L8,22.414L8.586,23L7,24.586 L6.414,24z M9,10.54V8h2.54l3.143,3.667l-1.85,2.159L9,10.54z M20.46,8H23v2.54L10.053,21.638l-0.69-0.69L20.46,8z M18.95,16.645 l3.688,4.302l-0.69,0.69l-4.411-3.781L18.95,16.645z M25,24.586L23.414,23L24,22.414L25.586,24L25,24.586z"/></svg>
+							<!-- Lucide Icons (ISC) - swords - https://lucide.dev/icons/swords -->
+							<svg class="navicon" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+								<g fill="none" stroke="var(--primary-stroke-color)" stroke-width="2" transform="translate(12 12) scale(1.3) translate(-12 -12)">
+									<path d="m13 19 6-6" />
+									<path d="M14.5 17.5 3.586 6.586A2 2 0 013 5.172V3h2.172a2 2 0 011.414.586L17.5 14.5" />
+									<path d="m14.828 6.172 2.586-2.586A2 2 0 0118.828 3H21v2.172a2 2 0 01-.586 1.414l-2.586 2.586" />
+									<path d="m16 16 4 4" />
+									<path d="m19 21 2-2" />
+									<path d="m5 14 4 4" />
+									<path d="m5 21-2-2" />
+									<path d="M7.5 16.5 4 20" />
+								</g>
+							</svg>
 							Join Game
 							<span id="seeks" class="badge padding-0">
 								<span id="seekcount" class="seekbadge">0</span><span id="seekcountbot">0</span>
@@ -140,7 +170,13 @@
 					<li>
 						<button class="navitem" style="min-width: 76px" onclick="$('#watchgame-modal').modal('show'); closeMobileMenu()"
 							data-toggle="tooltip" data-placement="auto" title="Games in progress">
-							<svg class="navicon verticle-align--middle" viewBox="0 0 576 512"><path d="M160 256C160 185.3 217.3 128 288 128C358.7 128 416 185.3 416 256C416 326.7 358.7 384 288 384C217.3 384 160 326.7 160 256zM288 336C332.2 336 368 300.2 368 256C368 211.8 332.2 176 288 176C287.3 176 286.7 176 285.1 176C287.3 181.1 288 186.5 288 192C288 227.3 259.3 256 224 256C218.5 256 213.1 255.3 208 253.1C208 254.7 208 255.3 208 255.1C208 300.2 243.8 336 288 336L288 336zM95.42 112.6C142.5 68.84 207.2 32 288 32C368.8 32 433.5 68.84 480.6 112.6C527.4 156 558.7 207.1 573.5 243.7C576.8 251.6 576.8 260.4 573.5 268.3C558.7 304 527.4 355.1 480.6 399.4C433.5 443.2 368.8 480 288 480C207.2 480 142.5 443.2 95.42 399.4C48.62 355.1 17.34 304 2.461 268.3C-.8205 260.4-.8205 251.6 2.461 243.7C17.34 207.1 48.62 156 95.42 112.6V112.6zM288 80C222.8 80 169.2 109.6 128.1 147.7C89.6 183.5 63.02 225.1 49.44 256C63.02 286 89.6 328.5 128.1 364.3C169.2 402.4 222.8 432 288 432C353.2 432 406.8 402.4 447.9 364.3C486.4 328.5 512.1 286 526.6 256C512.1 225.1 486.4 183.5 447.9 147.7C406.8 109.6 353.2 80 288 80V80z"/></svg>
+							<!-- PD icon https://www.svgrepo.com/svg/505373/eye-open -->
+							<svg class="verticle-align--middle" viewBox="0 0 24 24" fill="none">
+								<g fill="none" stroke="var(--primary-stroke-color)">
+									<path d="M12 5C5.63636 5 2 12 2 12C2 12 5.63636 19 12 19C18.3636 19 22 12 22 12C22 12 18.3636 5 12 5Z" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+									<path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+								</g>
+							</svg>
 							Watch
 							<span class="badge" id="gamecount">0</span>
 						</button>
@@ -150,14 +186,30 @@
 						class="navitem"
 						onclick="$('#help-modal').modal('show'); closeMobileMenu();"
 						data-toggle="tooltip" data-placement="auto" title="Information on game rules and Tak communities">
-							<svg class="navicon verticle-align--middle" viewBox="0 0 512 512"><path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256s256-114.6 256-256S397.4 0 256 0zM256 464c-114.7 0-208-93.31-208-208S141.3 48 256 48s208 93.31 208 208S370.7 464 256 464zM256 336c-18 0-32 14-32 32s13.1 32 32 32c17.1 0 32-14 32-32S273.1 336 256 336zM289.1 128h-51.1C199 128 168 159 168 198c0 13 11 24 24 24s24-11 24-24C216 186 225.1 176 237.1 176h51.1C301.1 176 312 186 312 198c0 8-4 14.1-11 18.1L244 251C236 256 232 264 232 272V288c0 13 11 24 24 24S280 301 280 288V286l45.1-28c21-13 34-36 34-60C360 159 329 128 289.1 128z"/></svg>
+							<!-- MIT Icon https://www.svgrepo.com/svg/445803/help-circle -->
+							<svg class="navicon-20 verticle-align--middle" viewBox="0 0 48 48">
+								<g>
+									<path d="M24,2A22,22,0,1,0,46,24,21.9,21.9,0,0,0,24,2Zm0,40A18,18,0,1,1,42,24,18.1,18.1,0,0,1,24,42Z"/>
+									<path d="M24,38h-.4l-.4-.2h-.3l-.3-.3-.3-.3c0-.1-.1-.2-.2-.3s0-.3-.1-.4v-.8c.1-.1.1-.2.1-.4s.2-.2.2-.3l.3-.3a1.9,1.9,0,0,1,1.8-.6h.4l.3.2.3.3.3.3c0,.1.1.2.1.3s.1.3.2.4v.8c-.1.1-.1.2-.2.4s-.1.2-.1.3l-.3.3-.3.3h-.3l-.4.2Z"/>
+									<path d="M24.4,30h-.8a2,2,0,0,1-1.1-2.6,7.3,7.3,0,0,1,3.6-3.9A4.9,4.9,0,0,0,25,14.1a5.3,5.3,0,0,0-4.2,1A5.3,5.3,0,0,0,19,18.9a2,2,0,0,1-4,0,8.8,8.8,0,0,1,3.3-6.8,8.8,8.8,0,0,1,7.5-1.9,8.9,8.9,0,0,1,2,16.8,3.7,3.7,0,0,0-1.6,1.7A1.9,1.9,0,0,1,24.4,30Z"/>
+								</g>
+							</svg>
 							Help
 						</button>
 					</li>
 					<li>
 						<a class="navitem" href="/games" target="_blank"
 						data-toggle="tooltip" data-placement="auto" title="Find and review old games">
-							<svg class="navicon verticle-align--middle" viewBox="0 0 24 24"><path d="M18.68,12.32C16.92,10.56 14.07,10.57 12.32,12.33C10.56,14.09 10.56,16.94 12.32,18.69C13.81,20.17 16.11,20.43 17.89,19.32L21,22.39L22.39,21L19.3,17.89C20.43,16.12 20.17,13.8 18.68,12.32M17.27,17.27C16.29,18.25 14.71,18.24 13.73,17.27C12.76,16.29 12.76,14.71 13.74,13.73C14.71,12.76 16.29,12.76 17.27,13.73C18.24,14.71 18.24,16.29 17.27,17.27M10.9,20.1C10.25,19.44 9.74,18.65 9.42,17.78C6.27,17.25 4,15.76 4,14V17C4,19.21 7.58,21 12,21V21C11.6,20.74 11.23,20.44 10.9,20.1M4,9V12C4,13.68 6.07,15.12 9,15.7C9,15.63 9,15.57 9,15.5C9,14.57 9.2,13.65 9.58,12.81C6.34,12.3 4,10.79 4,9M12,3C7.58,3 4,4.79 4,7C4,9 7,10.68 10.85,11H10.9C12.1,9.74 13.76,9 15.5,9C16.41,9 17.31,9.19 18.14,9.56C19.17,9.09 19.87,8.12 20,7C20,4.79 16.42,3 12,3Z"></path></svg>
+							<!-- MIT Icon https://www.svgrepo.com/svg/325099/db-search -->
+							<svg class="navicon-20 verticle-align--middle" viewBox="0 0 24 24" fill="none">
+								<g stroke="var(--primary-stroke-color)">
+									<path d="M20.5 20.5L22 22" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+									<path d="M16 18.5C16 19.8807 17.1193 21 18.5 21C19.1916 21 19.8175 20.7192 20.2701 20.2654C20.7211 19.8132 21 19.1892 21 18.5C21 17.1193 19.8807 16 18.5 16C17.1193 16 16 17.1193 16 18.5Z" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+									<path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6"  fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+									<path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z"  fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+									<path d="M11 21C4 21 4 18 4 18V12"  fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+								</g>
+							</svg>
 							Games Database
 						</a>
 					</li>
@@ -167,7 +219,8 @@
 							id="events-button"
 							onclick="showEvents(); closeMobileMenu();"
 							data-toggle="tooltip" data-placement="auto" title="View Events">
-							<svg class="navicon verticle-align--middle usta-nav" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" id="svg3485" version="1.1" inkscape:version="0.91 r13725" width="617.8125" height="508.125" viewBox="0 0 617.8125 508.125" sodipodi:docname="USTA Logo Vector.svg">
+							<!-- USTA Logo -->
+							<svg class="navicon verticle-align--middle usta-nav" inkscape:version="0.91 r13725" width="617.8125" height="508.125" viewBox="0 0 617.8125 508.125" sodipodi:docname="USTA Logo Vector.svg">
 								<defs id="defs3489" />
 								<g inkscape:groupmode="layer" id="layer3" inkscape:label="Board Trace" style="display:inline">
 									<path class="inverse-line" style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:7.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 5.5532787,216.57787 310.05806,4.6277322 611.7862,228.60997 301.72814,502.57172 Z" id="path3496" inkscape:connector-curvature="0" />
@@ -218,26 +271,31 @@
 						onclick="$('#online-players-modal').modal('show'); closeMobileMenu();"
 						data-toggle="tooltip"
 						title="Show active online players, and total number of online players">
-							<svg class="navicon verticle-align--middle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><path d="M352 128c0 70.7-57.3 128-128 128s-128-57.3-128-128S153.3 0 224 0s128 57.3 128 128zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3zM609.3 512H471.4c5.4-9.4 8.6-20.3 8.6-32v-8c0-60.7-27.1-115.2-69.8-151.8c2.4-.1 4.7-.2 7.1-.2h61.4C567.8 320 640 392.2 640 481.3c0 17-13.8 30.7-30.7 30.7zM432 256c-31 0-59-12.6-79.3-32.9C372.4 196.5 384 163.6 384 128c0-26.8-6.6-52.1-18.3-74.3C384.3 40.1 407.2 32 432 32c61.9 0 112 50.1 112 112s-50.1 112-112 112z"/></svg>
+							<!-- MIT Icon https://www.svgrepo.com/svg/347809/people -->
+							<svg class="navicon-20 verticle-align--middle" viewBox="0 0 24 24">
+								<g stroke="var(--primary-fill-color)" stroke-width="0.6">
+									<path fill-rule="evenodd" d="M3.5 8a5.5 5.5 0 118.596 4.547 9.005 9.005 0 015.9 8.18.75.75 0 01-1.5.045 7.5 7.5 0 00-14.993 0 .75.75 0 01-1.499-.044 9.005 9.005 0 015.9-8.181A5.494 5.494 0 013.5 8zM9 4a4 4 0 100 8 4 4 0 000-8z"/>
+									<path d="M17.29 8c-.148 0-.292.01-.434.03a.75.75 0 11-.212-1.484 4.53 4.53 0 013.38 8.097 6.69 6.69 0 013.956 6.107.75.75 0 01-1.5 0 5.193 5.193 0 00-3.696-4.972l-.534-.16v-1.676l.41-.209A3.03 3.03 0 0017.29 8z"/>
+								</g>
+							</svg>
 							Online <span class="badge" id="onlineplayersbadge">0</span>
 						</button>
 					</li>
 					<li>
 						<a class="navitem" data-toggle="tooltip" data-placement="auto" title="Find players on discord" href="https://discord.gg/2xEt42X" target="_blank" rel="noopener noreferrer">
-							<svg
-								class="verticle-align--middle"
-								viewBox="0 0 640 512"
-							>
-								<path
-									d="M524.531,69.836a1.5,1.5,0,0,0-.764-.7A485.065,485.065,0,0,0,404.081,32.03a1.816,1.816,0,0,0-1.923.91,337.461,337.461,0,0,0-14.9,30.6,447.848,447.848,0,0,0-134.426,0,309.541,309.541,0,0,0-15.135-30.6,1.89,1.89,0,0,0-1.924-.91A483.689,483.689,0,0,0,116.085,69.137a1.712,1.712,0,0,0-.788.676C39.068,183.651,18.186,294.69,28.43,404.354a2.016,2.016,0,0,0,.765,1.375A487.666,487.666,0,0,0,176.02,479.918a1.9,1.9,0,0,0,2.063-.676A348.2,348.2,0,0,0,208.12,430.4a1.86,1.86,0,0,0-1.019-2.588,321.173,321.173,0,0,1-45.868-21.853,1.885,1.885,0,0,1-.185-3.126c3.082-2.309,6.166-4.711,9.109-7.137a1.819,1.819,0,0,1,1.9-.256c96.229,43.917,200.41,43.917,295.5,0a1.812,1.812,0,0,1,1.924.233c2.944,2.426,6.027,4.851,9.132,7.16a1.884,1.884,0,0,1-.162,3.126,301.407,301.407,0,0,1-45.89,21.83,1.875,1.875,0,0,0-1,2.611,391.055,391.055,0,0,0,30.014,48.815,1.864,1.864,0,0,0,2.063.7A486.048,486.048,0,0,0,610.7,405.729a1.882,1.882,0,0,0,.765-1.352C623.729,277.594,590.933,167.465,524.531,69.836ZM222.491,337.58c-28.972,0-52.844-26.587-52.844-59.239S193.056,219.1,222.491,219.1c29.665,0,53.306,26.82,52.843,59.239C275.334,310.993,251.924,337.58,222.491,337.58Zm195.38,0c-28.971,0-52.843-26.587-52.843-59.239S388.437,219.1,417.871,219.1c29.667,0,53.307,26.82,52.844,59.239C470.715,310.993,447.538,337.58,417.871,337.58Z"
-								/>
+							<!-- Apache Icon https://www.svgrepo.com/svg/504277/discord -->
+							<svg class="verticle-align--middle" viewBox="0 0 192 192" fill="none">
+								<g fill="none" stroke="var(--primary-fill-color)">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="12" d="m68 138-8 16c-10.19-4.246-20.742-8.492-31.96-15.8-3.912-2.549-6.284-6.88-6.378-11.548-.488-23.964 5.134-48.056 19.369-73.528 1.863-3.334 4.967-5.778 8.567-7.056C58.186 43.02 64.016 40.664 74 39l6 11s6-2 16-2 16 2 16 2l6-11c9.984 1.664 15.814 4.02 24.402 7.068 3.6 1.278 6.704 3.722 8.567 7.056 14.235 25.472 19.857 49.564 19.37 73.528-.095 4.668-2.467 8.999-6.379 11.548-11.218 7.308-21.769 11.554-31.96 15.8l-8-16m-68-8s20 10 40 10 40-10 40-10"/>
+									<ellipse cx="71" cy="101" rx="13" ry="15" fill="var(--primary-fill-color)" />
+									<ellipse cx="121" cy="101" rx="13" ry="15" fill="var(--primary-fill-color)" />
+								</g>
 							</svg>
 							Find Players
 						</a>
 					</li>
 				</ul>
 			</nav>
-
 		</header>
 
 		<div id="floating">
@@ -247,10 +305,15 @@
 				data-toggle="tooltip" data-placement="auto" title="Click to show/hide notation"
 				onclick="adjustsidemenu('toggle',null)"
 			>
-				<svg id="notation-arrow" class="rotate-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-					<path
-						d="M342.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L274.7 256 105.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-					/>
+				<!-- PD Icon https://www.svgrepo.com/svg/511422/arrow-right-336 -->
+				<svg id="notation-arrow" class="rotate-arrow" viewBox="-4.5 0 20 20">
+					<g stroke-width="2" fill-rule="evenodd">
+						<g transform="translate(-305.000000, -6679.000000)">
+							<g transform="translate(56.000000, 160.000000)">
+								<path d="M249.365851,6538.70769 L249.365851,6538.70769 C249.770764,6539.09744 250.426289,6539.09744 250.830166,6538.70769 L259.393407,6530.44413 C260.202198,6529.66364 260.202198,6528.39747 259.393407,6527.61699 L250.768031,6519.29246 C250.367261,6518.90671 249.720021,6518.90172 249.314072,6519.28247 L249.314072,6519.28247 C248.899839,6519.67121 248.894661,6520.31179 249.302681,6520.70653 L257.196934,6528.32352 C257.601847,6528.71426 257.601847,6529.34685 257.196934,6529.73759 L249.365851,6537.29462 C248.960938,6537.68437 248.960938,6538.31795 249.365851,6538.70769" ></path>
+							</g>
+						</g>
+					</g>
 				</svg>
 			</div>
 
@@ -258,10 +321,10 @@
 				<div class="center player-box">
 					<div id="player-opp">
 						<div class="flex flex-center flex-align-center gap--8">
+							<!-- TODO refactor this -->
 							<svg
 								id="player-opp-img"
 								class="playerimg iswhite"
-								xmlns="http://www.w3.org/2000/svg"
 								viewBox="0 0 448 512"
 							>
 								<defs>
@@ -307,11 +370,9 @@
 						onclick="undoButton()"
 						data-toggle="tooltip" data-placement="auto" title="Undo move - Only works if your opponent undoes as well"
 					>
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-							<path
-								id="undo"
-								d="M212.333 224.333H12c-6.627 0-12-5.373-12-12V12C0 5.373 5.373 0 12 0h48c6.627 0 12 5.373 12 12v78.112C117.773 39.279 184.26 7.47 258.175 8.007c136.906.994 246.448 111.623 246.157 248.532C504.041 393.258 393.12 504 256.333 504c-64.089 0-122.496-24.313-166.51-64.215-5.099-4.622-5.334-12.554-.467-17.42l33.967-33.967c4.474-4.474 11.662-4.717 16.401-.525C170.76 415.336 211.58 432 256.333 432c97.268 0 176-78.716 176-176 0-97.267-78.716-176-176-176-58.496 0-110.28 28.476-142.274 72.333h98.274c6.627 0 12 5.373 12 12v48c0 6.627-5.373 12-12 12z"
-							></path>
+						<!-- PD Icon https://www.svgrepo.com/svg/499658/undo -->
+						<svg class="action-icon" viewBox="0 0 24 24" fill="none">
+							<path fill-rule="evenodd" clip-rule="evenodd" d="M8.70714 3.29289C9.09766 3.68342 9.09766 4.31658 8.70714 4.70711L6.41424 7H14C17.866 7 21 10.134 21 14C21 17.866 17.866 21 14 21H8.15388C7.60159 21 7.15388 20.5523 7.15388 20C7.15388 19.4477 7.60159 19 8.15388 19H14C16.7615 19 19 16.7614 19 14C19 11.2386 16.7615 9 14 9H6.41424L8.70714 11.2929C9.09766 11.6834 9.09766 12.3166 8.70714 12.7071C8.31661 13.0976 7.68345 13.0976 7.29292 12.7071L2.58582 8L7.29292 3.29289C7.68345 2.90237 8.31661 2.90237 8.70714 3.29289Z"/>
 						</svg>
 					</button>
 					<button
@@ -319,11 +380,12 @@
 						onclick="server.draw()"
 						data-toggle="tooltip" data-placement="auto" title="Request draw - Game is drawn if your opponent agrees"
 					>
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
-							<path
-								id="draw"
-								d="M519.2 127.9l-47.6-47.6A56.252 56.252 0 0 0 432 64H205.2c-14.8 0-29.1 5.9-39.6 16.3L118 127.9H0v255.7h64c17.6 0 31.8-14.2 31.9-31.7h9.1l84.6 76.4c30.9 25.1 73.8 25.7 105.6 3.8 12.5 10.8 26 15.9 41.1 15.9 18.2 0 35.3-7.4 48.8-24 22.1 8.7 48.2 2.6 64-16.8l26.2-32.3c5.6-6.9 9.1-14.8 10.9-23h57.9c.1 17.5 14.4 31.7 31.9 31.7h64V127.9H519.2zM48 351.6c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16c0 8.9-7.2 16-16 16zm390-6.9l-26.1 32.2c-2.8 3.4-7.8 4-11.3 1.2l-23.9-19.4-30 36.5c-6 7.3-15 4.8-18 2.4l-36.8-31.5-15.6 19.2c-13.9 17.1-39.2 19.7-55.3 6.6l-97.3-88H96V175.8h41.9l61.7-61.6c2-.8 3.7-1.5 5.7-2.3H262l-38.7 35.5c-29.4 26.9-31.1 72.3-4.4 101.3 14.8 16.2 61.2 41.2 101.5 4.4l8.2-7.5 108.2 87.8c3.4 2.8 3.9 7.9 1.2 11.3zm106-40.8h-69.2c-2.3-2.8-4.9-5.4-7.7-7.7l-102.7-83.4 12.5-11.4c6.5-6 7-16.1 1-22.6L367 167.1c-6-6.5-16.1-6.9-22.6-1l-55.2 50.6c-9.5 8.7-25.7 9.4-34.6 0-9.3-9.9-8.5-25.1 1.2-33.9l65.6-60.1c7.4-6.8 17-10.5 27-10.5l83.7-.2c2.1 0 4.1.8 5.5 2.3l61.7 61.6H544v128zm48 47.7c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16c0 8.9-7.2 16-16 16z"
-							></path>
+						<!-- MLP Icon https://www.svgrepo.com/svg/448461/handshake -->
+						<svg class="action-icon" viewBox="0 0 16 16">
+							<g id="draw">
+								<path fill-rule="evenodd" d="M5 2.75a.75.75 0 00-.53.22l-.78.78H.75a.75.75 0 000 1.5H2v5a.75.75 0 01-.75.75h-.5a.75.75 0 000 1.5h.5a2.25 2.25 0 002.016-1.25h.557l3.063 1.531a2.25 2.25 0 002.254-.14l2.087-1.391h1.507a2.25 2.25 0 002.016 1.25h.5a.75.75 0 000-1.5h-.5a.75.75 0 01-.75-.75v-5h1.25a.75.75 0 000-1.5h-2.94l-.78-.78a.75.75 0 00-.53-.22H5zm-1 2.5h-.5v4.5H4a.75.75 0 01.335.08l3.222 1.61a.75.75 0 00.751-.047l1.652-1.101-.584-.876a.75.75 0 011.248-.832l.777 1.166H12.5v-4.5H12a.75.75 0 01-.53-.22l-.78-.78H8.81L7.065 5.997a.711.711 0 00.971 1.038l.971-.85a.75.75 0 11.988 1.13l-.971.85a2.211 2.211 0 01-3.02-3.229l.686-.686H5.311l-.78.78A.75.75 0 014 5.25z" clip-rule="evenodd"/>
+								<path d="M1.25 9.625a.625.625 0 11-1.25 0 .625.625 0 011.25 0zM16 9.625a.625.625 0 11-1.25 0 .625.625 0 011.25 0z"/>
+							</g>
 						</svg>
 					</button>
 					<button
@@ -331,11 +393,10 @@
 						onclick="server.giveTime()"
 						data-toggle="tooltip" data-placement="auto" title="Give 15 seconds to your opponent"
 					>
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-							<path
-								d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z"
-							></path>
-							<text x="280" y="430" font-size="180" font-weight="bold" fill="currentColor">+</text>
+						<!-- Clock Plus Icon - Dazzle UI | https://www.svgrepo.com/svg/532112/clock-plus -->
+						<svg class="action-icon" viewBox="0 0 24 24" fill="transparent">
+							<path d="M12 16.5V8.5M16 12.5L8 12.5008M3 5.5L5 3.5M21 5.5L19 3.5M20 12.5C20 16.9183 16.4183 20.5 12 20.5C7.58172 20.5 4 16.9183 4 12.5C4 8.08172 7.58172 4.5 12 4.5C16.4183 4.5 20 8.08172 20 12.5Z" 
+							stroke="var(--primary-stroke-color)" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 						</svg>
 					</button>
 					<button
@@ -343,10 +404,12 @@
 						onclick="server.resign()"
 						data-toggle="tooltip" data-placement="auto" title="Resign - You lose the game immediately"
 					>
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-							<path
-								d="M336.174 80c-49.132 0-93.305-32-161.913-32-31.301 0-58.303 6.482-80.721 15.168a48.04 48.04 0 0 0 2.142-20.727C93.067 19.575 74.167 1.594 51.201.104 23.242-1.71 0 20.431 0 48c0 17.764 9.657 33.262 24 41.562V496c0 8.837 7.163 16 16 16h16c8.837 0 16-7.163 16-16v-83.443C109.869 395.28 143.259 384 199.826 384c49.132 0 93.305 32 161.913 32 58.479 0 101.972-22.617 128.548-39.981C503.846 367.161 512 352.051 512 335.855V95.937c0-34.459-35.264-57.768-66.904-44.117C409.193 67.309 371.641 80 336.174 80zM464 336c-21.783 15.412-60.824 32-102.261 32-59.945 0-102.002-32-161.913-32-43.361 0-96.379 9.403-127.826 24V128c21.784-15.412 60.824-32 102.261-32 59.945 0 102.002 32 161.913 32 43.271 0 96.32-17.366 127.826-32v240z"
-							></path>
+						<!-- MIT Icon https://www.svgrepo.com/svg/372434/flag -->
+						<svg class="action-icon" viewBox="0 0 36 36">
+							<g>
+								<path class="clr-i-outline clr-i-outline-path-1" d="M6,34a1.5,1.5,0,0,1-1.5-1.5V3A1.5,1.5,0,0,1,7.5,3V32.5A1.5,1.5,0,0,1,6,34Z"/>
+								<path class="clr-i-outline clr-i-outline-path-2" d="M30.55,3.82a1,1,0,0,0-1,0,14.9,14.9,0,0,1-6.13,1.16,13.11,13.11,0,0,1-5.18-1.49,12.78,12.78,0,0,0-5-1.45A10.86,10.86,0,0,0,9,2.85V5.08A8.8,8.8,0,0,1,13.25,4a11.22,11.22,0,0,1,4.2,1.28,14.84,14.84,0,0,0,6,1.66A18.75,18.75,0,0,0,29,6.12V18.95a16.16,16.16,0,0,1-5.58.93,13.11,13.11,0,0,1-5.18-1.49,12.78,12.78,0,0,0-5-1.45A10.86,10.86,0,0,0,9,17.79V20a8.8,8.8,0,0,1,4.25-1.08,11.22,11.22,0,0,1,4.2,1.28,14.84,14.84,0,0,0,6,1.66,16.79,16.79,0,0,0,7-1.37,1,1,0,0,0,.55-.89V4.67A1,1,0,0,0,30.55,3.82Z" stroke="var(--primary-fill-color)" stroke-width="1" stroke-linejoin="round"/>
+							</g>
 						</svg>
 					</button>
 				</div>
@@ -356,32 +419,40 @@
 				</div>
 
 				<div class="optlist center">
-					<button class="navitem" onclick="fastrewind()">
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-							<path
-								d="M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z"
-							></path>
+					<button class="navitem" onclick="fastrewind()" data-toggle="tooltip" data-placement="auto" title="Jump to the start of the game">
+						<!-- PD Icon https://www.svgrepo.com/svg/489570/player-previous -->
+						<svg class="action-icon" viewBox="0 0 24 24" fill="none">
+							<g clip-path="url(#clip0_429_11234)" fill="none" stroke="var(--primary-stroke-color)">
+								<path d="M21 17.1962L21 6.80387C21 5.26427 19.3333 4.30202 18 5.07182L15 6.80387L15 17.1962L18 18.9282C19.3333 19.698 21 18.7358 21 17.1962Z" stroke-width="2" stroke-linejoin="round"/>
+								<path d="M3 13.7321C1.66667 12.9623 1.66667 11.0377 3 10.2679L12 5.0718C13.3333 4.302 15 5.26425 15 6.80385L15 17.1962C15 18.7358 13.3333 19.698 12 18.9282L3 13.7321Z" stroke-width="2" stroke-linejoin="round"/>
+							</g>
 						</svg>
 					</button>
-					<button class="navitem" onclick="stepback()">
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
-							<path
-								d="M64 468V44c0-6.6 5.4-12 12-12h48c6.6 0 12 5.4 12 12v176.4l195.5-181C352.1 22.3 384 36.6 384 64v384c0 27.4-31.9 41.7-52.5 24.6L136 292.7V468c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12z"
-							></path>
+					<button class="navitem" onclick="stepback()" data-toggle="tooltip" data-placement="auto" title="Step back one move">
+						<!-- PD Icon https://www.svgrepo.com/svg/489569/player-start -->
+						<svg class="action-icon" viewBox="0 0 24 24" fill="none">
+							<g clip-path="url(#clip0_429_11145)" fill="none" stroke="var(--primary-stroke-color)">
+								<path d="M7 13.7321C5.66667 12.9623 5.66667 11.0377 7 10.2679L16 5.0718C17.3333 4.302 19 5.26425 19 6.80385L19 17.1962C19 18.7358 17.3333 19.698 16 18.9282L7 13.7321Z" stroke-width="2" stroke-linejoin="round"/>
+								<path d="M4 19L4 5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+							</g>
 						</svg>
 					</button>
-					<button class="navitem" onclick="stepforward()">
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
-							<path
-								d="M384 44v424c0 6.6-5.4 12-12 12h-48c-6.6 0-12-5.4-12-12V291.6l-195.5 181C95.9 489.7 64 475.4 64 448V64c0-27.4 31.9-41.7 52.5-24.6L312 219.3V44c0-6.6 5.4-12 12-12h48c6.6 0 12 5.4 12 12z"
-							></path>
+					<button class="navitem" onclick="stepforward()" data-toggle="tooltip" data-placement="auto" title="Step forward one move">
+						<!-- PD Icon https://www.svgrepo.com/svg/489564/player-end -->
+						<svg class="action-icon" viewBox="0 0 24 24" fill="none">
+							<g clip-path="url(#clip0_429_11142)" fill="none" stroke="var(--primary-stroke-color)">
+								<path d="M17 10.2679C18.3333 11.0377 18.3333 12.9623 17 13.7321L8 18.9282C6.66667 19.698 5 18.7358 5 17.1962L5 6.80385C5 5.26425 6.66667 4.302 8 5.0718L17 10.2679Z" stroke-width="2" stroke-linejoin="round"/>
+								<path d="M20 5V19" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+							</g>
 						</svg>
 					</button>
-					<button class="navitem" onclick="fastforward()">
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-							<path
-								d="M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z"
-							></path>
+					<button class="navitem" onclick="fastforward()" data-toggle="tooltip" data-placement="auto" title="Jump to the end of the game">
+						<!-- PD Icon https://www.svgrepo.com/svg/489566/player-next -->
+						<svg class="action-icon" viewBox="0 0 24 24" fill="none">
+							<g clip-path="url(#clip0_429_11073)" fill="none" stroke="var(--primary-stroke-color)">
+								<path d="M3 6.80383V17.1961C3 18.7357 4.66667 19.698 6 18.9282L9 17.1961L9 6.80383L6 5.07177C4.66667 4.30197 3 5.26423 3 6.80383Z" stroke-width="2" stroke-linejoin="round"/>
+								<path d="M21 10.2679C22.3333 11.0377 22.3333 12.9623 21 13.7321L12 18.9282C10.6667 19.698 9 18.7358 9 17.1962L9 6.80385C9 5.26425 10.6667 4.302 12 5.0718L21 10.2679Z" stroke-width="2" stroke-linejoin="round"/>
+							</g>
 						</svg>
 					</button>
 				</div>
@@ -394,10 +465,9 @@
 						data-toggle="tooltip" data-placement="auto" title="Download the game as a PTN-file"
 						href="#"
 					>
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-							<path
-								d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm76.45 211.36l-96.42 95.7c-6.65 6.61-17.39 6.61-24.04 0l-96.42-95.7C73.42 337.29 80.54 320 94.82 320H160v-80c0-8.84 7.16-16 16-16h32c8.84 0 16 7.16 16 16v80h65.18c14.28 0 21.4 17.29 11.27 27.36zM377 105L279.1 7c-4.5-4.5-10.6-7-17-7H256v128h128v-6.1c0-6.3-2.5-12.4-7-16.9z"
-							></path>
+						<!-- PD Icon https://www.svgrepo.com/svg/381635/file-download -->
+						<svg class="action-icon" viewBox="0 0 24 24">
+							<path fill-rule="evenodd" d="M15,3.41421356 L15,7 L18.5857864,7 L15,3.41421356 Z M19,9 L15,9 C13.8954305,9 13,8.1045695 13,7 L13,3 L5,3 L5,21 L19,21 L19,9 Z M5,1 L15.4142136,1 L21,6.58578644 L21,21 C21,22.1045695 20.1045695,23 19,23 L5,23 C3.8954305,23 3,22.1045695 3,21 L3,3 C3,1.8954305 3.8954305,1 5,1 Z M11,14.5857864 L11,10 L13,10 L13,14.5857864 L14.2928932,13.2928932 L15.7071068,14.7071068 L12,18.4142136 L8.29289322,14.7071068 L9.70710678,13.2928932 L11,14.5857864 Z"/>
 						</svg>
 					</a>
 					<button
@@ -405,10 +475,9 @@
 						onclick="copyNotationLink()"
 						data-toggle="tooltip" data-placement="auto" title="Copy a link to this game to your clipboard"
 					>
-						<svg class="action-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
-							<path
-								d="M433.941 65.941l-51.882-51.882A48 48 0 0 0 348.118 0H176c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h224c26.51 0 48-21.49 48-48v-48h80c26.51 0 48-21.49 48-48V99.882a48 48 0 0 0-14.059-33.941zM266 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h74v224c0 26.51 21.49 48 48 48h96v42a6 6 0 0 1-6 6zm128-96H182a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h106v88c0 13.255 10.745 24 24 24h88v202a6 6 0 0 1-6 6zm6-256h-64V48h9.632c1.591 0 3.117.632 4.243 1.757l48.368 48.368a6 6 0 0 1 1.757 4.243V112z"
-							></path>
+						<!-- MLP Icon https://www.svgrepo.com/svg/503047/link -->
+						<svg class="action-icon" viewBox="0 0 24 24" fill="none">
+							<path fill-rule="evenodd" clip-rule="evenodd" d="M10.975 14.51a1.05 1.05 0 0 0 0-1.485 2.95 2.95 0 0 1 0-4.172l3.536-3.535a2.95 2.95 0 1 1 4.172 4.172l-1.093 1.092a1.05 1.05 0 0 0 1.485 1.485l1.093-1.092a5.05 5.05 0 0 0-7.142-7.142L9.49 7.368a5.05 5.05 0 0 0 0 7.142c.41.41 1.075.41 1.485 0zm2.05-5.02a1.05 1.05 0 0 0 0 1.485 2.95 2.95 0 0 1 0 4.172l-3.5 3.5a2.95 2.95 0 1 1-4.171-4.172l1.025-1.025a1.05 1.05 0 0 0-1.485-1.485L3.87 12.99a5.05 5.05 0 0 0 7.142 7.142l3.5-3.5a5.05 5.05 0 0 0 0-7.142 1.05 1.05 0 0 0-1.485 0z"/>
 						</svg>
 					</button>
 				</div>
@@ -416,10 +485,11 @@
 				<div class="center player-box">
 					<div id="player-me">
 						<div class="flex flex-center flex-align-center gap--8">
+							<!-- TODO refactor these  -->
 							<svg
 								id="player-me-img"
 								class="playerimg isblack"
-								xmlns="http://www.w3.org/2000/svg"
+							
 								viewBox="0 0 448 512"
 							>
 								<defs>
@@ -445,24 +515,27 @@
 				data-toggle="tooltip" data-placement="auto" title="Click to show/hide chat"
 				onclick="adjustsidemenu(null,'toggle')"
 			>
-				<svg id="chat-arrow" class="" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-					<path
-						d="M342.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L274.7 256 105.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-					/>
+				<!-- PD Icon https://www.svgrepo.com/svg/511422/arrow-right-336 -->
+				<svg id="chat-arrow" class="" viewBox="-4.5 0 20 20">
+					<g stroke-width="2" fill-rule="evenodd">
+						<g transform="translate(-305.000000, -6679.000000)">
+							<g transform="translate(56.000000, 160.000000)">
+								<path d="M249.365851,6538.70769 L249.365851,6538.70769 C249.770764,6539.09744 250.426289,6539.09744 250.830166,6538.70769 L259.393407,6530.44413 C260.202198,6529.66364 260.202198,6528.39747 259.393407,6527.61699 L250.768031,6519.29246 C250.367261,6518.90671 249.720021,6518.90172 249.314072,6519.28247 L249.314072,6519.28247 C248.899839,6519.67121 248.894661,6520.31179 249.302681,6520.70653 L257.196934,6528.32352 C257.601847,6528.71426 257.601847,6529.34685 257.196934,6529.73759 L249.365851,6537.29462 C248.960938,6537.68437 248.960938,6538.31795 249.365851,6538.70769" ></path>
+							</g>
+						</g>
+					</g>
 				</svg>
 			</div>
 			<div id="cmenu" class="flex flex-column">
 				<div>
 					<a class="btn btn-pill btn-primary btn-slim margin-bottom--8 flex flex-align-center flex-center" href="https://discord.gg/2xEt42X" target="_blank" rel="noopener noreferrer">
-						<svg
-							class="margin-right--8 verticle-align--middle"
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 640 512"
-						>
-							<!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
-							<path
-								d="M524.531,69.836a1.5,1.5,0,0,0-.764-.7A485.065,485.065,0,0,0,404.081,32.03a1.816,1.816,0,0,0-1.923.91,337.461,337.461,0,0,0-14.9,30.6,447.848,447.848,0,0,0-134.426,0,309.541,309.541,0,0,0-15.135-30.6,1.89,1.89,0,0,0-1.924-.91A483.689,483.689,0,0,0,116.085,69.137a1.712,1.712,0,0,0-.788.676C39.068,183.651,18.186,294.69,28.43,404.354a2.016,2.016,0,0,0,.765,1.375A487.666,487.666,0,0,0,176.02,479.918a1.9,1.9,0,0,0,2.063-.676A348.2,348.2,0,0,0,208.12,430.4a1.86,1.86,0,0,0-1.019-2.588,321.173,321.173,0,0,1-45.868-21.853,1.885,1.885,0,0,1-.185-3.126c3.082-2.309,6.166-4.711,9.109-7.137a1.819,1.819,0,0,1,1.9-.256c96.229,43.917,200.41,43.917,295.5,0a1.812,1.812,0,0,1,1.924.233c2.944,2.426,6.027,4.851,9.132,7.16a1.884,1.884,0,0,1-.162,3.126,301.407,301.407,0,0,1-45.89,21.83,1.875,1.875,0,0,0-1,2.611,391.055,391.055,0,0,0,30.014,48.815,1.864,1.864,0,0,0,2.063.7A486.048,486.048,0,0,0,610.7,405.729a1.882,1.882,0,0,0,.765-1.352C623.729,277.594,590.933,167.465,524.531,69.836ZM222.491,337.58c-28.972,0-52.844-26.587-52.844-59.239S193.056,219.1,222.491,219.1c29.665,0,53.306,26.82,52.843,59.239C275.334,310.993,251.924,337.58,222.491,337.58Zm195.38,0c-28.971,0-52.843-26.587-52.843-59.239S388.437,219.1,417.871,219.1c29.667,0,53.307,26.82,52.844,59.239C470.715,310.993,447.538,337.58,417.871,337.58Z"
-							/>
+						<!-- Apache Icon https://www.svgrepo.com/svg/504277/discord -->
+						<svg class="margin-right--8 verticle-align--middle" viewBox="0 0 192 192" fill="none">
+							<g fill="none" stroke="white">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="12" d="m68 138-8 16c-10.19-4.246-20.742-8.492-31.96-15.8-3.912-2.549-6.284-6.88-6.378-11.548-.488-23.964 5.134-48.056 19.369-73.528 1.863-3.334 4.967-5.778 8.567-7.056C58.186 43.02 64.016 40.664 74 39l6 11s6-2 16-2 16 2 16 2l6-11c9.984 1.664 15.814 4.02 24.402 7.068 3.6 1.278 6.704 3.722 8.567 7.056 14.235 25.472 19.857 49.564 19.37 73.528-.095 4.668-2.467 8.999-6.379 11.548-11.218 7.308-21.769 11.554-31.96 15.8l-8-16m-68-8s20 10 40 10 40-10 40-10"/>
+								<ellipse cx="71" cy="101" rx="13" ry="15" fill="white" />
+								<ellipse cx="121" cy="101" rx="13" ry="15" fill="white" />
+							</g>
 						</svg>
 						Find Players
 					</a>
@@ -474,7 +547,12 @@
 						<input type="text" class="form-control" id="chat-me" />
 						<div>
 							<button id="send-button" type="submit" class="btn btn-pill btn-secondary btn-slim fullw margin-top--8  flex flex-align-center flex-center">
-								<svg class="svg-small margin-right--8 fill-primary" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M498.1 5.6c10.1 7 15.4 19.1 13.5 31.2l-64 416c-1.5 9.7-7.4 18.2-16 23s-18.9 5.4-28 1.6L277.3 424.9l-40.1 74.5c-5.2 9.7-16.3 14.6-27 11.9S192 499 192 488V392c0-5.3 1.8-10.5 5.1-14.7L362.4 164.7c2.5-7.1-6.5-14.3-13-8.4L170.4 318.2l-32 28.9 0 0c-9.2 8.3-22.3 10.6-33.8 5.8l-85-35.4C8.4 312.8 .8 302.2 .1 290s5.5-23.7 16.1-29.8l448-256c10.7-6.1 23.9-5.5 34 1.4z"/></svg>
+								<!-- PD Icon https://www.svgrepo.com/svg/502827/send-2 -->
+								<svg class="svg-small margin-right--8 fill-primary" viewBox="0 0 24 24" fill="none">
+									<g fill="none" stroke="var(--primary-fill-color)">
+										<path d="M20 4L3 9.31372L10.5 13.5M20 4L14.5 21L10.5 13.5M20 4L10.5 13.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+									</g>
+								</svg>
 								Send
 							</button>
 						</div>
@@ -488,27 +566,55 @@
 				<div class="flex flex-space-between">
 					<h4 class="padding-left--8">Settings</h4>
 					<button class="btn btn-link" onclick="toggleSettingsDrawer(false)">
-						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" class="fill-primary"><path d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"/></svg>
+						 <!-- MLP Icon https://www.svgrepo.com/svg/503004/close -->
+						<svg class="fill-primary"> viewBox="0 0 24 24" fill="none">
+							<path fill-rule="evenodd" clip-rule="evenodd" d="M19.207 6.207a1 1 0 0 0-1.414-1.414L12 10.586 6.207 4.793a1 1 0 0 0-1.414 1.414L10.586 12l-5.793 5.793a1 1 0 1 0 1.414 1.414L12 13.414l5.793 5.793a1 1 0 0 0 1.414-1.414L13.414 12l5.793-5.793z"/>
+						</svg>
 					</button>
 				</div>
 				<ul class="nav nav-tabs">
 					<li class="nav-item" role="presentation" data-toggle="tooltip" data-placement="top" title="Board and pieces styling">
 						<a href="#board" class="nav-link active" data-toggle="tab">
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="fill-primary">
-								<path
-									d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm64 64v64h64V96h64v64h64V96h64v64H320v64h64v64H320v64h64v64H320V352H256v64H192V352H128v64H64V352h64V288H64V224h64V160H64V96h64zm64 128h64V160H192v64zm0 64V224H128v64h64zm64 0H192v64h64V288zm0 0h64V224H256v64z"
-								/>
+							<!-- PD Icon https://www.svgrepo.com/svg/511661/chess-1218 -->
+							<svg class="fill-primary" viewBox="0 0 20 20">
+								<g stroke-width="1" fill-rule="evenodd">
+									<g transform="translate(-220.000000, -2719.000000)">
+										<g transform="translate(56.000000, 160.000000)">
+											<path d="M174,2573 L178,2573 L178,2569 L174,2569 L174,2573 Z M170,2569 L174,2569 L174,2565 L170,2565 L170,2569 Z M182,2565 L178,2565 L178,2569 L182,2569 L182,2573 L178,2573 L178,2577 L174,2577 L174,2573 L170,2573 L170,2577 L167,2577 C166.448,2577 166,2576.657 166,2576.105 L166,2573 L170,2573 L170,2569 L166,2569 L166,2565 L170,2565 L170,2561 L174,2561 L174,2565 L178,2565 L178,2561 L181,2561 C181.552,2561 182,2561.552 182,2562.105 L182,2565 Z M182,2559 L166,2559 C164.895,2559 164,2559.895 164,2561 L164,2577 C164,2578.104 164.895,2579 166,2579 L182,2579 C183.105,2579 184,2578.104 184,2577 L184,2561 C184,2559.895 183.105,2559 182,2559 L182,2559 Z" ></path>
+										</g>
+									</g>
+								</g>
 							</svg>
 						</a>
 					</li>
 					<li class="nav-item" role="presentation" data-toggle="tooltip" data-placement="top" title="Interface settings">
 						<a href="#interface" class="nav-link" data-toggle="tab">
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="fill-primary"><path d="M0 416c0-17.7 14.3-32 32-32l54.7 0c12.3-28.3 40.5-48 73.3-48s61 19.7 73.3 48L480 384c17.7 0 32 14.3 32 32s-14.3 32-32 32l-246.7 0c-12.3 28.3-40.5 48-73.3 48s-61-19.7-73.3-48L32 448c-17.7 0-32-14.3-32-32zm192 0c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zM384 256c0-17.7-14.3-32-32-32s-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32zm-32-80c32.8 0 61 19.7 73.3 48l54.7 0c17.7 0 32 14.3 32 32s-14.3 32-32 32l-54.7 0c-12.3 28.3-40.5 48-73.3 48s-61-19.7-73.3-48L32 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l246.7 0c12.3-28.3 40.5-48 73.3-48zM192 64c-17.7 0-32 14.3-32 32s14.3 32 32 32s32-14.3 32-32s-14.3-32-32-32zm73.3 0L480 64c17.7 0 32 14.3 32 32s-14.3 32-32 32l-214.7 0c-12.3 28.3-40.5 48-73.3 48s-61-19.7-73.3-48L32 128C14.3 128 0 113.7 0 96S14.3 64 32 64l86.7 0C131 35.7 159.2 16 192 16s61 19.7 73.3 48z"/></svg>
+							<!-- MIT Icon https://www.svgrepo.com/svg/348314/controls-alt -->
+							<svg class="stroke-primary" viewBox="0 0 24 24" fill="none">
+								<g stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+									<circle cx="9" cy="6" r="2" fill="none"/>
+									<path d="M4 6H7"/>
+									<path d="M11 6H20"/>
+									<circle cx="9" cy="18" r="2" fill="none"/>
+									<path d="M4 18H7"/>
+									<path d="M11 18H20"/>
+									<circle cx="15" cy="12" r="2" fill="none"/>
+									<path d="M4 12H13"/>
+									<path d="M17 12L20 12"/> 
+								</g>
+							</svg>
 						</a>
 					</li>
 					<li class="nav-item" role="presentation" data-toggle="tooltip" data-placement="top" title="Account settings">
 						<a href="#account" class="nav-link" data-toggle="tab">
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="fill-primary"><path d="M224 256c-70.7 0-128-57.3-128-128S153.3 0 224 0s128 57.3 128 128s-57.3 128-128 128zm-45.7 48h91.4c11.8 0 23.4 1.2 34.5 3.3c-2.1 18.5 7.4 35.6 21.8 44.8c-16.6 10.6-26.7 31.6-20 53.3c4 12.9 9.4 25.5 16.4 37.6s15.2 23.1 24.4 33c15.7 16.9 39.6 18.4 57.2 8.7v.9c0 9.2 2.7 18.5 7.9 26.3H29.7C13.3 512 0 498.7 0 482.3C0 383.8 79.8 304 178.3 304zM436 218.2c0-7 4.5-13.3 11.3-14.8c10.5-2.4 21.5-3.7 32.7-3.7s22.2 1.3 32.7 3.7c6.8 1.5 11.3 7.8 11.3 14.8v30.6c7.9 3.4 15.4 7.7 22.3 12.8l24.9-14.3c6.1-3.5 13.7-2.7 18.5 2.4c7.6 8.1 14.3 17.2 20.1 27.2s10.3 20.4 13.5 31c2.1 6.7-1.1 13.7-7.2 17.2l-25 14.4c.4 4 .7 8.1 .7 12.3s-.2 8.2-.7 12.3l25 14.4c6.1 3.5 9.2 10.5 7.2 17.2c-3.3 10.6-7.8 21-13.5 31s-12.5 19.1-20.1 27.2c-4.8 5.1-12.5 5.9-18.5 2.4l-24.9-14.3c-6.9 5.1-14.3 9.4-22.3 12.8l0 30.6c0 7-4.5 13.3-11.3 14.8c-10.5 2.4-21.5 3.7-32.7 3.7s-22.2-1.3-32.7-3.7c-6.8-1.5-11.3-7.8-11.3-14.8V454.8c-8-3.4-15.6-7.7-22.5-12.9l-24.7 14.3c-6.1 3.5-13.7 2.7-18.5-2.4c-7.6-8.1-14.3-17.2-20.1-27.2s-10.3-20.4-13.5-31c-2.1-6.7 1.1-13.7 7.2-17.2l24.8-14.3c-.4-4.1-.7-8.2-.7-12.4s.2-8.3 .7-12.4L343.8 325c-6.1-3.5-9.2-10.5-7.2-17.2c3.3-10.6 7.7-21 13.5-31s12.5-19.1 20.1-27.2c4.8-5.1 12.4-5.9 18.5-2.4l24.8 14.3c6.9-5.1 14.5-9.4 22.5-12.9V218.2zm92.1 133.5c0-26.5-21.5-48-48.1-48s-48.1 21.5-48.1 48s21.5 48 48.1 48s48.1-21.5 48.1-48z"/></svg>
+							<!-- PD Icon https://www.svgrepo.com/svg/502786/password-2 -->
+							<svg class="stroke-primary" viewBox="0 0 24 24" fill="none">
+								<g fill="none">
+									<path d="M21 8.5V6C21 4.89543 20.1046 4 19 4H5C3.89543 4 3 4.89543 3 6V11C3 12.1046 3.89543 13 5 13H10.875M19 14V12C19 10.8954 18.1046 10 17 10C15.8954 10 15 10.8954 15 12V14M14 20H20C20.5523 20 21 19.5523 21 19V15C21 14.4477 20.5523 14 20 14H14C13.4477 14 13 14.4477 13 15V19C13 19.5523 13.4477 20 14 20Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+									<circle cx="7.5" cy="8.5" r="1.5"/>
+									<circle cx="12" cy="8.5" r="1.5"/>
+								</g>
+							</svg>
 						</a>
 					</li>
 				</ul>
@@ -901,7 +1007,10 @@
 				<div class="modal-content">
 					<div class="modal-header">
 						<h4 class="modal-title">
-							<svg viewBox="0 0 24 24"><path d="M19 17H22V19H19V22H17V19H14V17H17V14H19V17M8 16H12V12H8V16M12 12H16V8H12V12M2 2V22H13.54C13 21.42 12.63 20.74 12.36 20H8V16H4V12H8V8H4V4H8V8H12V4H16V8H20V12.36C20.74 12.63 21.42 13 22 13.54V2H2Z"></path></svg>
+							<!-- MDI Icon (Apache 2.0) - checkerboard-plus - https://pictogrammers.com/library/mdi/icon/checkerboard-plus/ -->
+							<svg viewBox="0 0 24 24">
+								<path d="M19 17H22V19H19V22H17V19H14V17H17V14H19V17M8 16H12V12H8V16M12 12H16V8H12V12M2 2V22H13.54C13 21.42 12.63 20.74 12.36 20H8V16H4V12H8V8H4V4H8V8H12V4H16V8H20V12.36C20.74 12.63 21.42 13 22 13.54V2H2Z"></path>
+							</svg>
 							New Game
 						</h4>
 						<button type="button" class="close" data-dismiss="modal">&times;</button>
@@ -910,14 +1019,19 @@
 						<ul class="nav nav-tabs" role="tablist">
 							<li class="nav-item">
 								<a
-									class=" nav-link active"
+									class="nav-link active"
 									data-toggle="tab"
 									href="#create-game"
 									role="tab"
 									aria-controls="create-game"
 									aria-selected="true"
 								>
-									<svg class="stroke-primary" viewBox="0 0 24 24" fill="none"><g id="Edit / Add_Plus_Circle"><path fill="none" d="M8 12H12M12 12H16M12 12V16M12 12V8M12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12C21 16.9706 16.9706 21 12 21Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></g></svg>
+									<!-- MIT Icon https://www.svgrepo.com/svg/500504/circle-plus -->
+									<svg class="stroke-primary" viewBox="0 0 1024 1024">
+										<path d="M352 480h320a32 32 0 1 1 0 64H352a32 32 0 0 1 0-64z"/>
+										<path d="M480 672V352a32 32 0 1 1 64 0v320a32 32 0 0 1-64 0z"/>
+										<path d="M512 896a384 384 0 1 0 0-768 384 384 0 0 0 0 768zm0 64a448 448 0 1 1 0-896 448 448 0 0 1 0 896z"/>
+									</svg>
 									Create Game
 								</a>
 							</li>
@@ -930,7 +1044,10 @@
 									aria-controls="play-scratch"
 									aria-selected="false"
 								>
-								<svg viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.8787 3.70705C17.0503 2.53547 18.9498 2.53548 20.1213 3.70705L20.2929 3.87862C21.4645 5.05019 21.4645 6.94969 20.2929 8.12126L18.5556 9.85857L8.70713 19.7071C8.57897 19.8352 8.41839 19.9261 8.24256 19.9701L4.24256 20.9701C3.90178 21.0553 3.54129 20.9554 3.29291 20.7071C3.04453 20.4587 2.94468 20.0982 3.02988 19.7574L4.02988 15.7574C4.07384 15.5816 4.16476 15.421 4.29291 15.2928L14.1989 5.38685L15.8787 3.70705ZM18.7071 5.12126C18.3166 4.73074 17.6834 4.73074 17.2929 5.12126L16.3068 6.10738L17.8622 7.72357L18.8787 6.70705C19.2692 6.31653 19.2692 5.68336 18.8787 5.29283L18.7071 5.12126ZM16.4477 9.13804L14.8923 7.52185L5.90299 16.5112L5.37439 18.6256L7.48877 18.097L16.4477 9.13804Z"/></svg>
+									<!-- MIT Icon https://www.svgrepo.com/svg/509349/edit-2 -->
+									<svg viewBox="0 0 20 20" fill="none">
+										<path fill-rule="evenodd" d="M15.198 3.52a1.612 1.612 0 012.223 2.336L6.346 16.421l-2.854.375 1.17-3.272L15.197 3.521zm3.725-1.322a3.612 3.612 0 00-5.102-.128L3.11 12.238a1 1 0 00-.253.388l-1.8 5.037a1 1 0 001.072 1.328l4.8-.63a1 1 0 00.56-.267L18.8 7.304a3.612 3.612 0 00.122-5.106zM12 17a1 1 0 100 2h6a1 1 0 100-2h-6z"/>
+									</svg>
 									Play Scratch
 								</a>
 							</li>
@@ -943,7 +1060,10 @@
 									aria-controls="load-game"
 									aria-selected="false"
 								>
-								<svg class="stroke-primary" fill="none" viewBox="0 0 24 24"><path fill="none" d="M17 17H17.01M15.6 14H18C18.9319 14 19.3978 14 19.7654 14.1522C20.2554 14.3552 20.6448 14.7446 20.8478 15.2346C21 15.6022 21 16.0681 21 17C21 17.9319 21 18.3978 20.8478 18.7654C20.6448 19.2554 20.2554 19.6448 19.7654 19.8478C19.3978 20 18.9319 20 18 20H6C5.06812 20 4.60218 20 4.23463 19.8478C3.74458 19.6448 3.35523 19.2554 3.15224 18.7654C3 18.3978 3 17.9319 3 17C3 16.0681 3 15.6022 3.15224 15.2346C3.35523 14.7446 3.74458 14.3552 4.23463 14.1522C4.60218 14 5.06812 14 6 14H8.4M12 15V4M12 4L15 7M12 4L9 7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+									<!-- MIT Icon https://www.svgrepo.com/svg/435972/upload -->
+									<svg viewBox="-0.01 0 16.021 16.021" id="upload-16px">
+										<path id="Path_19" data-name="Path 19" d="M26.172,4.877a.5.5,0,0,1-.05-.7l3.5-4.029a.519.519,0,0,1,.756,0l3.5,4.029a.5.5,0,0,1-.756.656L30.5,1.809V12.5a.5.5,0,0,1-1,0V1.809L26.878,4.828A.5.5,0,0,1,26.172,4.877ZM35,12.5a.5.5,0,1,0-.5.5A.5.5,0,0,0,35,12.5ZM35.5,8h-2a.5.5,0,0,0,0,1h2A1.5,1.5,0,0,1,37,10.5v3A1.5,1.5,0,0,1,35.5,15h-11A1.5,1.5,0,0,1,23,13.5v-3A1.5,1.5,0,0,1,24.5,9h2a.5.5,0,0,0,0-1h-2A2.5,2.5,0,0,0,22,10.5v3A2.5,2.5,0,0,0,24.5,16h11A2.5,2.5,0,0,0,38,13.5v-3A2.5,2.5,0,0,0,35.5,8Z" transform="translate(-22 0.021)"/>
+									</svg>
 									Load Game
 								</a>
 							</li>
@@ -1122,7 +1242,17 @@
 												<div class="card-header" id="headingOne">
 													<h2 class="margin--0">
 														<button class="btn btn-link btn-block left btn-nav-accordion" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-															<svg class="verticle-align--middle fa-chevron-right fill-primary" viewBox="0 0 320 512"><path d="M278.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-160 160c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L210.7 256 73.4 118.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l160 160z"/></svg> Advanced Options
+															<!-- PD Icon https://www.svgrepo.com/svg/511422/arrow-right-336 -->
+															<svg class="verticle-align--middle fa-chevron-right fill-primary svg-small" viewBox="-4.5 0 20 20">
+																<g stroke-width="2" fill-rule="evenodd">
+																	<g transform="translate(-305.000000, -6679.000000)">
+																		<g transform="translate(56.000000, 160.000000)">
+																			<path d="M249.365851,6538.70769 L249.365851,6538.70769 C249.770764,6539.09744 250.426289,6539.09744 250.830166,6538.70769 L259.393407,6530.44413 C260.202198,6529.66364 260.202198,6528.39747 259.393407,6527.61699 L250.768031,6519.29246 C250.367261,6518.90671 249.720021,6518.90172 249.314072,6519.28247 L249.314072,6519.28247 C248.899839,6519.67121 248.894661,6520.31179 249.302681,6520.70653 L257.196934,6528.32352 C257.601847,6528.71426 257.601847,6529.34685 257.196934,6529.73759 L249.365851,6537.29462 C248.960938,6537.68437 248.960938,6538.31795 249.365851,6538.70769" ></path>
+																		</g>
+																	</g>
+																</g>
+															</svg>
+															Advanced Options
 														</button>
 													</h2>
 												</div>
@@ -1338,37 +1468,65 @@
 						</div>
 						<div class="flex flex-column gap--8 fullw">
 							<div class="flex flex-center flex-wrap gap--8">
-								<button onclick="copyGameIdToClipboard()" data-toggle="tooltip" data-placement="top" title="Copy game ID to your clipboard" class="game-over-action-button btn btn-pill btn-secondary">
-									<svg viewBox="0 0 448 512"><path d="M433.941 65.941l-51.882-51.882A48 48 0 0 0 348.118 0H176c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h224c26.51 0 48-21.49 48-48v-48h80c26.51 0 48-21.49 48-48V99.882a48 48 0 0 0-14.059-33.941zM266 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h74v224c0 26.51 21.49 48 48 48h96v42a6 6 0 0 1-6 6zm128-96H182a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h106v88c0 13.255 10.745 24 24 24h88v202a6 6 0 0 1-6 6zm6-256h-64V48h9.632c1.591 0 3.117.632 4.243 1.757l48.368 48.368a6 6 0 0 1 1.757 4.243V112z"></path></svg>
+								<button onclick="copyGameIdToClipboard()" data-toggle="tooltip" data-placement="top" title="Copy game ID to your clipboard" class="game-over-action-button btn btn-pill btn-secondary hidden">
+									<!-- MIT Icon https://www.svgrepo.com/svg/500354/copy -->
+									<svg viewBox="0 0 16 16">
+										<path d="M13.49 3 10.74.37A1.22 1.22 0 0 0 9.86 0h-4a1.25 1.25 0 0 0-1.22 1.25v11a1.25 1.25 0 0 0 1.25 1.25h6.72a1.25 1.25 0 0 0 1.25-1.25V3.88a1.22 1.22 0 0 0-.37-.88zm-.88 9.25H5.89v-11h2.72v2.63a1.25 1.25 0 0 0 1.25 1.25h2.75zm0-8.37H9.86V1.25l2.75 2.63z"/>
+										<path d="M10.11 14.75H3.39v-11H4V2.5h-.61a1.25 1.25 0 0 0-1.25 1.25v11A1.25 1.25 0 0 0 3.39 16h6.72a1.25 1.25 0 0 0 1.25-1.25v-.63h-1.25z"/>
+									</svg>
 									Copy Game ID
 								</button>
-								<button id="rematch" onclick="server.rematch()" data-toggle="tooltip" data-placement="top" title="Request a rematch to the other player" class="game-over-action-button btn btn-pill btn-secondary hidden">
-									<svg viewBox="0 0 32 32"><path d="M28.414,24l-3-3l2.293-2.293l-1.414-1.414l-2.236,2.236l-3.588-4.186L25,11.46V6h-5.46L16,10.13  L12.46,6H7v5.46l4.531,3.884l-3.588,4.186l-2.236-2.236l-1.414,1.414L6.586,21l-3,3L7,27.414l3-3l2.293,2.293l1.414-1.414  l-2.237-2.237L16,19.174l4.53,3.882l-2.237,2.237l1.414,1.414L22,24.414l3,3L28.414,24z M6.414,24L8,22.414L8.586,23L7,24.586  L6.414,24z M9,10.54V8h2.54l3.143,3.667l-1.85,2.159L9,10.54z M20.46,8H23v2.54L10.053,21.638l-0.69-0.69L20.46,8z M18.95,16.645 l3.688,4.302l-0.69,0.69l-4.411-3.781L18.95,16.645z M25,24.586L23.414,23L24,22.414L25.586,24L25,24.586z"/></svg>
+								<button id="rematch" onclick="server.rematch()" data-toggle="tooltip" data-placement="top" title="Request a rematch to the other player" class="game-over-action-button btn btn-pill btn-secondary">
+									<!-- Lucide Icons (ISC) - swords - https://lucide.dev/icons/swords -->
+									<svg class="navicon-20" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+										<g fill="none" stroke="var(--primary-stroke-color)" stroke-width="2" transform="translate(12 12) scale(1.3) translate(-12 -12)">
+											<path d="m13 19 6-6" />
+											<path d="M14.5 17.5 3.586 6.586A2 2 0 013 5.172V3h2.172a2 2 0 011.414.586L17.5 14.5" />
+											<path d="m14.828 6.172 2.586-2.586A2 2 0 0118.828 3H21v2.172a2 2 0 01-.586 1.414l-2.586 2.586" />
+											<path d="m16 16 4 4" />
+											<path d="m19 21 2-2" />
+											<path d="m5 14 4 4" />
+											<path d="m5 21-2-2" />
+											<path d="M7.5 16.5 4 20" />
+										</g>
+									</svg>
 									Request Rematch
 								</button>
 							</div>
 							<div class="flex flex-center flex-wrap gap--8">
 								<button onclick="copyNotationToClipboard()" data-toggle="tooltip" data-placement="top" title="Copy PTN output of this game to your clipboard" class="game-over-action-button btn btn-pill btn-secondary">
-									<svg viewBox="0 0 448 512">
-										<path d="M433.941 65.941l-51.882-51.882A48 48 0 0 0 348.118 0H176c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h224c26.51 0 48-21.49 48-48v-48h80c26.51 0 48-21.49 48-48V99.882a48 48 0 0 0-14.059-33.941zM266 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h74v224c0 26.51 21.49 48 48 48h96v42a6 6 0 0 1-6 6zm128-96H182a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h106v88c0 13.255 10.745 24 24 24h88v202a6 6 0 0 1-6 6zm6-256h-64V48h9.632c1.591 0 3.117.632 4.243 1.757l48.368 48.368a6 6 0 0 1 1.757 4.243V112z"></path>
+									<!-- MIT Icon https://www.svgrepo.com/svg/500354/copy -->
+									<svg viewBox="0 0 16 16">
+										<path d="M13.49 3 10.74.37A1.22 1.22 0 0 0 9.86 0h-4a1.25 1.25 0 0 0-1.22 1.25v11a1.25 1.25 0 0 0 1.25 1.25h6.72a1.25 1.25 0 0 0 1.25-1.25V3.88a1.22 1.22 0 0 0-.37-.88zm-.88 9.25H5.89v-11h2.72v2.63a1.25 1.25 0 0 0 1.25 1.25h2.75zm0-8.37H9.86V1.25l2.75 2.63z"/>
+										<path d="M10.11 14.75H3.39v-11H4V2.5h-.61a1.25 1.25 0 0 0-1.25 1.25v11A1.25 1.25 0 0 0 3.39 16h6.72a1.25 1.25 0 0 0 1.25-1.25v-.63h-1.25z"/>
 									</svg>
 									Copy PTN Text
 								</button>
 								<a href="#" onclick="openInPtnNinja()" data-toggle="tooltip" data-placement="top" title="Open this game in PTN Ninja" class="game-over-action-button btn btn-pill btn-secondary">
-									<svg viewBox="0 0 24 24" width="24px" style="stroke: none"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></svg>
+									<!-- MIT Icon https://www.svgrepo.com/svg/326731/open-outline -->
+									<svg viewBox="0 0 512 512">
+										<g stroke="var(--primary-stroke-color)" stroke-width="40">
+											<path d="M384,224V408a40,40,0,0,1-40,40H104a40,40,0,0,1-40-40V168a40,40,0,0,1,40-40H271.48" style="fill:none; stroke-linecap:round; stroke-linejoin:round;" />
+											<polyline points="336 64 448 64 448 176" style="fill:none; stroke-linecap:round; stroke-linejoin:round;" />
+											<line x1="224" y1="288" x2="440" y2="72" style="fill:none; stroke-linecap:round; stroke-linejoin:round;" />
+										</g>
+									</svg>
 									Open in PTN Ninja
 								</a>
 							</div>
 							<div class="flex flex-wrap gap--8 flex-center">
 								<a id="download_notation_go" onclick="downloadNotation('download_notation_go')" data-toggle="tooltip" data-placement="top" title="Download the game as a PTN file" href="#" class="game-over-action-button btn btn-pill btn-secondary">
-									<svg viewBox="0 0 384 512">
-										<path d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm76.45 211.36l-96.42 95.7c-6.65 6.61-17.39 6.61-24.04 0l-96.42-95.7C73.42 337.29 80.54 320 94.82 320H160v-80c0-8.84 7.16-16 16-16h32c8.84 0 16 7.16 16 16v80h65.18c14.28 0 21.4 17.29 11.27 27.36zM377 105L279.1 7c-4.5-4.5-10.6-7-17-7H256v128h128v-6.1c0-6.3-2.5-12.4-7-16.9z"></path>
+									<!-- PD Icon https://www.svgrepo.com/svg/381635/file-download -->
+									<svg viewBox="0 0 24 24">
+										<path fill-rule="evenodd" d="M15,3.41421356 L15,7 L18.5857864,7 L15,3.41421356 Z M19,9 L15,9 C13.8954305,9 13,8.1045695 13,7 L13,3 L5,3 L5,21 L19,21 L19,9 Z M5,1 L15.4142136,1 L21,6.58578644 L21,21 C21,22.1045695 20.1045695,23 19,23 L5,23 C3.8954305,23 3,22.1045695 3,21 L3,3 C3,1.8954305 3.8954305,1 5,1 Z M11,14.5857864 L11,10 L13,10 L13,14.5857864 L14.2928932,13.2928932 L15.7071068,14.7071068 L12,18.4142136 L8.29289322,14.7071068 L9.70710678,13.2928932 L11,14.5857864 Z"/>
 									</svg>
 									Download PTN
 								</a>
 								<button onclick="copyNotationLink()" data-toggle="tooltip" data-placement="top" title="Copy play tak link to this game to your clipboard" class="game-over-action-button btn btn-pill btn-secondary">
-									<svg viewBox="0 0 24 24" width="24px" style="transform: rotate(-45deg)">
-										<path d="M17 7h-4v2h4c1.65 0 3 1.35 3 3s-1.35 3-3 3h-4v2h4c2.76 0 5-2.24 5-5s-2.24-5-5-5zm-6 8H7c-1.65 0-3-1.35-3-3s1.35-3 3-3h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-2zm-3-4h8v2H8z"/></svg>
+									<!-- MLP Icon https://www.svgrepo.com/svg/503047/link -->
+									<svg viewBox="0 0 24 24" fill="none">
+										<path fill-rule="evenodd" clip-rule="evenodd" d="M10.975 14.51a1.05 1.05 0 0 0 0-1.485 2.95 2.95 0 0 1 0-4.172l3.536-3.535a2.95 2.95 0 1 1 4.172 4.172l-1.093 1.092a1.05 1.05 0 0 0 1.485 1.485l1.093-1.092a5.05 5.05 0 0 0-7.142-7.142L9.49 7.368a5.05 5.05 0 0 0 0 7.142c.41.41 1.075.41 1.485 0zm2.05-5.02a1.05 1.05 0 0 0 0 1.485 2.95 2.95 0 0 1 0 4.172l-3.5 3.5a2.95 2.95 0 1 1-4.171-4.172l1.025-1.025a1.05 1.05 0 0 0-1.485-1.485L3.87 12.99a5.05 5.05 0 0 0 7.142 7.142l3.5-3.5a5.05 5.05 0 0 0 0-7.142 1.05 1.05 0 0 0-1.485 0z"/>
+									</svg>
 									Copy Play Tak Link
 								</button>
 							</div>
@@ -1386,8 +1544,8 @@
 					<div class="header flex flex-center flex-align-center width--100">
 						<div class="hero flex flex-center flex-wrap gap--32">
 							<div class="playtak-logo">
-								<!-- logo -->
-								<svg viewBox="1.557 0.657 156.84 85.815" xmlns="http://www.w3.org/2000/svg">
+								<!-- Playtak logo -->
+								<svg viewBox="1.557 0.657 156.84 85.815">
 									<g transform="matrix(1, 0, 0, 1, -22.049961, -66.840012)">
 										<g stroke="#000" stroke-width=".63283">
 										<path d="m77.739 107.8h-20.183a0.026458 0.026458 45 0 1-0.02646-0.0265v-34.35a0.026458 0.026458 135 0 1 0.02646-0.02646h7.1822a0.026458 0.026458 45 0 1 0.02646 0.02646v27.696a0.026458 0.026458 45 0 0 0.02646 0.0265h12.948a0.026458 0.026458 45 0 1 0.02646 0.0265v6.6012a0.026458 0.026458 135 0 1-0.02646 0.0265z"/>
@@ -1425,7 +1583,8 @@
 							</div>
 							<div class="hero-actions flex flex-column">
 								<div id="loading" class="loading flex flex-column flex-align-center flex-center" style="display: none;">
-									<svg width="100px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 322 333" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
+									<!-- Tak loading Icon -->
+									<svg width="100px" viewBox="0 0 322 333" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
 										<style>
 										#eIZHlkQSopD2_to {animation: eIZHlkQSopD2_to__to 2400ms linear infinite normal forwards}@keyframes eIZHlkQSopD2_to__to { 0% {transform: translate(156.137404px,-68.747306px)} 25% {transform: translate(158.448219px,236.280287px)} 100% {transform: translate(158.448219px,236.280287px)}} #eIZHlkQSopD10_to {animation: eIZHlkQSopD10_to__to 2400ms linear infinite normal forwards}@keyframes eIZHlkQSopD10_to__to { 0% {transform: translate(159.586113px,-65.806554px)} 33.333333% {transform: translate(159.586113px,-65.806554px)} 58.333333% {transform: translate(161.896928px,183.761477px)} 100% {transform: translate(161.896928px,183.761477px)}} #eIZHlkQSopD19_to {animation: eIZHlkQSopD19_to__to 2400ms linear infinite normal forwards}@keyframes eIZHlkQSopD19_to__to { 0% {transform: translate(158.408461px,-95.253131px)} 66.666667% {transform: translate(158.408461px,-95.253131px)} 91.666667% {transform: translate(157.253053px,102.899263px)} 100% {transform: translate(157.253053px,102.899263px)}}
 										</style>
@@ -1465,15 +1624,13 @@
 									<button id="signup-button" class="btn btn-pill btn-primary margin-bottom--8 flex flex-center flex-align-center" onclick="hideElement('hero-actions'); showElement('sign-up')">Sign Up</button>
 									<button id="landing-login-button" class="btn btn-pill btn-secondary margin-bottom--8 flex flex-center flex-align-center" onclick="hideElement('hero-actions'); showElement('landing-login')">Log In</button>
 									<a class="btn btn-pill btn-primary margin-bottom--8 flex flex-center flex-align-center" href="https://discord.gg/2xEt42X" target="_blank" rel="noopener noreferrer">
-										<svg
-											class="verticle-align--middle"
-											xmlns="http://www.w3.org/2000/svg"
-											viewBox="0 0 640 512"
-										>
-											<!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
-											<path
-												d="M524.531,69.836a1.5,1.5,0,0,0-.764-.7A485.065,485.065,0,0,0,404.081,32.03a1.816,1.816,0,0,0-1.923.91,337.461,337.461,0,0,0-14.9,30.6,447.848,447.848,0,0,0-134.426,0,309.541,309.541,0,0,0-15.135-30.6,1.89,1.89,0,0,0-1.924-.91A483.689,483.689,0,0,0,116.085,69.137a1.712,1.712,0,0,0-.788.676C39.068,183.651,18.186,294.69,28.43,404.354a2.016,2.016,0,0,0,.765,1.375A487.666,487.666,0,0,0,176.02,479.918a1.9,1.9,0,0,0,2.063-.676A348.2,348.2,0,0,0,208.12,430.4a1.86,1.86,0,0,0-1.019-2.588,321.173,321.173,0,0,1-45.868-21.853,1.885,1.885,0,0,1-.185-3.126c3.082-2.309,6.166-4.711,9.109-7.137a1.819,1.819,0,0,1,1.9-.256c96.229,43.917,200.41,43.917,295.5,0a1.812,1.812,0,0,1,1.924.233c2.944,2.426,6.027,4.851,9.132,7.16a1.884,1.884,0,0,1-.162,3.126,301.407,301.407,0,0,1-45.89,21.83,1.875,1.875,0,0,0-1,2.611,391.055,391.055,0,0,0,30.014,48.815,1.864,1.864,0,0,0,2.063.7A486.048,486.048,0,0,0,610.7,405.729a1.882,1.882,0,0,0,.765-1.352C623.729,277.594,590.933,167.465,524.531,69.836ZM222.491,337.58c-28.972,0-52.844-26.587-52.844-59.239S193.056,219.1,222.491,219.1c29.665,0,53.306,26.82,52.843,59.239C275.334,310.993,251.924,337.58,222.491,337.58Zm195.38,0c-28.971,0-52.843-26.587-52.843-59.239S388.437,219.1,417.871,219.1c29.667,0,53.307,26.82,52.844,59.239C470.715,310.993,447.538,337.58,417.871,337.58Z"
-											/>
+										<!-- Apache Icon https://www.svgrepo.com/svg/504277/discord -->
+										<svg class="verticle-align--middle" viewBox="0 0 192 192" fill="none">
+											<g fill="none" stroke="white">
+												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="12" d="m68 138-8 16c-10.19-4.246-20.742-8.492-31.96-15.8-3.912-2.549-6.284-6.88-6.378-11.548-.488-23.964 5.134-48.056 19.369-73.528 1.863-3.334 4.967-5.778 8.567-7.056C58.186 43.02 64.016 40.664 74 39l6 11s6-2 16-2 16 2 16 2l6-11c9.984 1.664 15.814 4.02 24.402 7.068 3.6 1.278 6.704 3.722 8.567 7.056 14.235 25.472 19.857 49.564 19.37 73.528-.095 4.668-2.467 8.999-6.379 11.548-11.218 7.308-21.769 11.554-31.96 15.8l-8-16m-68-8s20 10 40 10 40-10 40-10"/>
+												<ellipse cx="71" cy="101" rx="13" ry="15" fill="white" />
+												<ellipse cx="121" cy="101" rx="13" ry="15" fill="white" />
+											</g>
 										</svg>
 										Find Players
 									</a>
@@ -1597,10 +1754,24 @@
 						<div class="parallax-inner flex flex-center flex-align-center gap--32 width--100">
 							<h2 class="heading-text text-center padding--8">
 								<a href="https://ustak.org/play-beautiful-game-tak/" target="_blank" rel="noopener noreferrer">
-									<svg class="icon-40 verticle-align--bottom" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M320 32c-8.1 0-16.1 1.4-23.7 4.1L15.8 137.4C6.3 140.9 0 149.9 0 160s6.3 19.1 15.8 22.6l57.9 20.9C57.3 229.3 48 259.8 48 291.9v28.1c0 28.4-10.8 57.7-22.3 80.8c-6.5 13-13.9 25.8-22.5 37.6C0 442.7-.9 448.3 .9 453.4s6 8.9 11.2 10.2l64 16c4.2 1.1 8.7 .3 12.4-2s6.3-6.1 7.1-10.4c8.6-42.8 4.3-81.2-2.1-108.7C90.3 344.3 86 329.8 80 316.5V291.9c0-30.2 10.2-58.7 27.9-81.5c12.9-15.5 29.6-28 49.2-35.7l157-61.7c8.2-3.2 17.5 .8 20.7 9s-.8 17.5-9 20.7l-157 61.7c-12.4 4.9-23.3 12.4-32.2 21.6l159.6 57.6c7.6 2.7 15.6 4.1 23.7 4.1s16.1-1.4 23.7-4.1L624.2 182.6c9.5-3.4 15.8-12.5 15.8-22.6s-6.3-19.1-15.8-22.6L343.7 36.1C336.1 33.4 328.1 32 320 32zM128 408c0 35.3 86 72 192 72s192-36.7 192-72L496.7 262.6 354.5 314c-11.1 4-22.8 6-34.5 6s-23.5-2-34.5-6L143.3 262.6 128 408z"/></svg>
-									Learn to <span class="display--inline-block">play tak <svg class="icon-40 verticle-align--bottom" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"/></svg></span>
+									<!-- MIT Icon https://www.svgrepo.com/svg/450161/graduation-cap -->
+									<svg class="icon-40 verticle-align--bottom" viewBox="0 -3 24 24" id="meteor-icon-kit__regular-graduation-cap" fill="none">
+										<path fill-rule="evenodd" clip-rule="evenodd" d="M3.41661 5.99993L12 9.9015L20.5834 5.99993L12 2.09839L3.41661 5.99993zM0 5.99993C0 5.63356 0.195399 5.2672 0.586197 5.08956L11.1724 0.27766C11.6982 0.03863 12.3018 0.03863 12.8276 0.27766L23.4138 5.08956C24.1954 5.44483 24.1954 6.555 23.4138 6.9103L20 8.462V12.724C20 13.0995 19.8943 13.4675 19.6949 13.7858C18.1427 16.2633 15.5333 17.4999 12 17.4999C8.46671 17.4999 5.85733 16.2633 4.30518 13.7859C4.10583 13.4677 4.00009 13.0998 4 12.7241V8.462L2 7.5529V10.4999C2 11.0522 1.55228 11.4999 1 11.4999C0.447715 11.4999 0 11.0522 0 10.4999V5.99993zM18 9.3711L12.8276 11.7222C12.3018 11.9612 11.6982 11.9612 11.1724 11.7222L6.00001 9.3711L6.00004 12.724C7.15854 14.5732 9.11408 15.4999 12 15.4999C14.886 15.4999 16.8415 14.5732 18 12.724V9.3711z"/>
+									</svg>
+									Learn to <span class="display--inline-block">play tak
+									<!-- PD Icon https://www.svgrepo.com/svg/511427/arrow-right-363 -->
+									<svg class="icon-40 verticle-align--bottom" viewBox="0 0 20 20">
+										<g stroke="none" stroke-width="1" fill-rule="evenodd">
+											<g transform="translate(-420.000000, -6559.000000)">
+												<g transform="translate(56.000000, 160.000000)">
+													<path d="M375.127681,6399.29274 C374.737008,6398.90242 374.104537,6398.90242 373.714864,6399.29274 C373.324191,6399.68307 373.324191,6400.31497 373.714864,6400.7043 L380.149475,6407.14215 C380.464211,6407.45661 380.241398,6408.00167 379.79677,6408.00167 L365.016149,6408.00167 C364.464611,6408.00167 364,6408.44091 364,6408.99195 L364,6408.99594 C364,6409.54699 364.464611,6409.99821 365.016149,6409.99821 L379.79677,6409.99821 C380.241398,6409.99821 380.464211,6410.52829 380.149475,6410.84275 L373.68389,6417.29957 C373.293217,6417.68889 373.293217,6418.3188 373.68389,6418.70913 L373.68389,6418.70813 C374.073563,6419.09746 374.706034,6419.09746 375.096707,6418.70713 L383.41474,6410.39652 L383.41474,6410.39652 C384.195087,6409.61687 384.195087,6408.35206 383.41474,6407.57241 C383.233892,6407.39272 374.946832,6399.11206 375.127681,6399.29274"></path>
+												</g>
+											</g>
+										</g>
+									</svg>
+								</span>
 								</a>
-								</h2>
+							</h2>
 						</div>
 					</section>
 					<!-- Events and Matched -->
@@ -1609,7 +1780,12 @@
 							<div class="flex flex-space-between">
 								<h2>Upcoming <b>Events</b></h2>
 								<div id="close-events" style="display: none;">
-									<button class="btn btn-pill flex flex-center flex-align-center" data-toggle="tooltip" data-placement="auto" title="close" onclick="hideElement('landing')"><svg class="svg-accent" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"/></svg></button>
+									<button class="btn btn-pill flex flex-center flex-align-center" data-toggle="tooltip" data-placement="auto" title="close" onclick="hideElement('landing')">
+										<!-- MLP Icon https://www.svgrepo.com/svg/503004/close -->
+										<svg class="svg-accent" viewBox="0 0 24 24" fill="none">
+											<path fill-rule="evenodd" clip-rule="evenodd" d="M19.207 6.207a1 1 0 0 0-1.414-1.414L12 10.586 6.207 4.793a1 1 0 0 0-1.414 1.414L10.586 12l-5.793 5.793a1 1 0 1 0 1.414 1.414L12 13.414l5.793 5.793a1 1 0 0 0 1.414-1.414L13.414 12l5.793-5.793z"/>
+										</svg>
+									</button>
 								</div>
 							</div>
 
@@ -1627,7 +1803,8 @@
 								</table>
 							</div>
 							<div id="loading-events" class="loading flex flex-column flex-align-center flex-center" style="display: none;">
-								<svg id="eIZHlkQSopD1" width="100px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 322 333" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
+								<!-- Tak loading icon -->
+								<svg id="eIZHlkQSopD1" width="100px" viewBox="0 0 322 333" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
 									<style>
 										#eIZHlkQSopD21_to {animation: eIZHlkQSopD2_to__to 2400ms linear infinite normal forwards}
 										@keyframes eIZHlkQSopD2_to__to { 0% {transform: translate(156.137404px,-68.747306px)} 25% {transform: translate(158.448219px,236.280287px)} 100% {transform: translate(158.448219px,236.280287px)}}
@@ -1683,16 +1860,6 @@
 						<!-- powered by USTA -->
 						<div class="usta-logo-small">
 							<svg
-								xmlns:dc="http://purl.org/dc/elements/1.1/"
-								xmlns:cc="http://creativecommons.org/ns#"
-								xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-								xmlns:svg="http://www.w3.org/2000/svg"
-								xmlns="http://www.w3.org/2000/svg"
-								xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-								xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-								id="svg3485-1"
-								version="1.1"
-								inkscape:version="0.91 r13725"
 								width="617.8125"
 								height="508.125"
 								viewBox="0 0 617.8125 508.125"
@@ -1895,7 +2062,14 @@
 				<div class="modal-content">
 					<div class="modal-header">
 						<h4 class="modal-title">
-							<svg class="verticle-align--middle" viewBox="0 0 512 512"><path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256s256-114.6 256-256S397.4 0 256 0zM256 464c-114.7 0-208-93.31-208-208S141.3 48 256 48s208 93.31 208 208S370.7 464 256 464zM256 336c-18 0-32 14-32 32s13.1 32 32 32c17.1 0 32-14 32-32S273.1 336 256 336zM289.1 128h-51.1C199 128 168 159 168 198c0 13 11 24 24 24s24-11 24-24C216 186 225.1 176 237.1 176h51.1C301.1 176 312 186 312 198c0 8-4 14.1-11 18.1L244 251C236 256 232 264 232 272V288c0 13 11 24 24 24S280 301 280 288V286l45.1-28c21-13 34-36 34-60C360 159 329 128 289.1 128z"/></svg>
+							<!-- MIT Icon https://www.svgrepo.com/svg/445803/help-circle -->
+							<svg class="navicon-20 verticle-align--middle" viewBox="0 0 48 48">
+								<g>
+									<path d="M24,2A22,22,0,1,0,46,24,21.9,21.9,0,0,0,24,2Zm0,40A18,18,0,1,1,42,24,18.1,18.1,0,0,1,24,42Z"/>
+									<path d="M24,38h-.4l-.4-.2h-.3l-.3-.3-.3-.3c0-.1-.1-.2-.2-.3s0-.3-.1-.4v-.8c.1-.1.1-.2.1-.4s.2-.2.2-.3l.3-.3a1.9,1.9,0,0,1,1.8-.6h.4l.3.2.3.3.3.3c0,.1.1.2.1.3s.1.3.2.4v.8c-.1.1-.1.2-.2.4s-.1.2-.1.3l-.3.3-.3.3h-.3l-.4.2Z"/>
+									<path d="M24.4,30h-.8a2,2,0,0,1-1.1-2.6,7.3,7.3,0,0,1,3.6-3.9A4.9,4.9,0,0,0,25,14.1a5.3,5.3,0,0,0-4.2,1A5.3,5.3,0,0,0,19,18.9a2,2,0,0,1-4,0,8.8,8.8,0,0,1,3.3-6.8,8.8,8.8,0,0,1,7.5-1.9,8.9,8.9,0,0,1,2,16.8,3.7,3.7,0,0,0-1.6,1.7A1.9,1.9,0,0,1,24.4,30Z"/>
+								</g>
+							</svg>
 							Help
 						</h4>
 						<button type="button" class="close" data-dismiss="modal">&times;</button>
@@ -2043,7 +2217,13 @@
 											>
 										</li>
 										<li>Ticking sound by FoolBoyMedia.</li>
-										<li>Icons by Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc.</li>
+										<li>
+											Icons provided by
+											<ul>
+												<li> Clock Plus Icon - Dazzle UI | https://www.svgrepo.com/svg/532112/clock-plus </li>
+												<li> Message Square Plus Icon - Dazzle UI | https://www.svgrepo.com/svg/533278/message-square-plus </li>
+											</ul>
+										</li>
 										<li>
 											<a href="#" onclick="showPrivacyPolicy();"> Privacy Policy</a>
 										</li>
@@ -2196,7 +2376,19 @@
 				<div class="modal-content">
 					<div class="modal-header">
 						<h4 class="modal-title">
-							<svg viewBox="0 0 32 32"><path d="M28.414,24l-3-3l2.293-2.293l-1.414-1.414l-2.236,2.236l-3.588-4.186L25,11.46V6h-5.46L16,10.13  L12.46,6H7v5.46l4.531,3.884l-3.588,4.186l-2.236-2.236l-1.414,1.414L6.586,21l-3,3L7,27.414l3-3l2.293,2.293l1.414-1.414 l-2.237-2.237L16,19.174l4.53,3.882l-2.237,2.237l1.414,1.414L22,24.414l3,3L28.414,24z M6.414,24L8,22.414L8.586,23L7,24.586 L6.414,24z M9,10.54V8h2.54l3.143,3.667l-1.85,2.159L9,10.54z M20.46,8H23v2.54L10.053,21.638l-0.69-0.69L20.46,8z M18.95,16.645 l3.688,4.302l-0.69,0.69l-4.411-3.781L18.95,16.645z M25,24.586L23.414,23L24,22.414L25.586,24L25,24.586z"/></svg>
+							<!-- Lucide Icons (ISC) - swords - https://lucide.dev/icons/swords -->
+							<svg class="navicon" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+								<g fill="none" stroke="var(--primary-stroke-color)" stroke-width="2" transform="translate(12 12) scale(1.3) translate(-12 -12)">
+									<path d="m13 19 6-6" />
+									<path d="M14.5 17.5 3.586 6.586A2 2 0 013 5.172V3h2.172a2 2 0 011.414.586L17.5 14.5" />
+									<path d="m14.828 6.172 2.586-2.586A2 2 0 0118.828 3H21v2.172a2 2 0 01-.586 1.414l-2.586 2.586" />
+									<path d="m16 16 4 4" />
+									<path d="m19 21 2-2" />
+									<path d="m5 14 4 4" />
+									<path d="m5 21-2-2" />
+									<path d="M7.5 16.5 4 20" />
+								</g>
+							</svg>
 							Join Game
 						</h4>
 						<button type="button" class="close" data-dismiss="modal">&times;</button>
@@ -2246,7 +2438,13 @@
 				<div class="modal-content">
 					<div class="modal-header">
 						<h4 class="modal-title">
-							<svg class="verticle-align--middle" viewBox="0 0 576 512"><path d="M160 256C160 185.3 217.3 128 288 128C358.7 128 416 185.3 416 256C416 326.7 358.7 384 288 384C217.3 384 160 326.7 160 256zM288 336C332.2 336 368 300.2 368 256C368 211.8 332.2 176 288 176C287.3 176 286.7 176 285.1 176C287.3 181.1 288 186.5 288 192C288 227.3 259.3 256 224 256C218.5 256 213.1 255.3 208 253.1C208 254.7 208 255.3 208 255.1C208 300.2 243.8 336 288 336L288 336zM95.42 112.6C142.5 68.84 207.2 32 288 32C368.8 32 433.5 68.84 480.6 112.6C527.4 156 558.7 207.1 573.5 243.7C576.8 251.6 576.8 260.4 573.5 268.3C558.7 304 527.4 355.1 480.6 399.4C433.5 443.2 368.8 480 288 480C207.2 480 142.5 443.2 95.42 399.4C48.62 355.1 17.34 304 2.461 268.3C-.8205 260.4-.8205 251.6 2.461 243.7C17.34 207.1 48.62 156 95.42 112.6V112.6zM288 80C222.8 80 169.2 109.6 128.1 147.7C89.6 183.5 63.02 225.1 49.44 256C63.02 286 89.6 328.5 128.1 364.3C169.2 402.4 222.8 432 288 432C353.2 432 406.8 402.4 447.9 364.3C486.4 328.5 512.1 286 526.6 256C512.1 225.1 486.4 183.5 447.9 147.7C406.8 109.6 353.2 80 288 80V80z"/></svg>
+							<!-- PD icon https://www.svgrepo.com/svg/505373/eye-open -->
+							<svg class="verticle-align--middle" viewBox="0 0 24 24" fill="none">
+								<g fill="none" stroke="var(--primary-stroke-color)">
+									<path d="M12 5C5.63636 5 2 12 2 12C2 12 5.63636 19 12 19C18.3636 19 22 12 22 12C22 12 18.3636 5 12 5Z" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+									<path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+								</g>
+							</svg>
 							Watch Game</h4>
 						<button type="button" class="close" data-dismiss="modal">&times;</button>
 					</div>
@@ -2275,7 +2473,13 @@
 				<div class="modal-content">
 					<div class="modal-header">
 						<h4 class="modal-title">
-							<svg class="verticle-align--middle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><path d="M352 128c0 70.7-57.3 128-128 128s-128-57.3-128-128S153.3 0 224 0s128 57.3 128 128zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3zM609.3 512H471.4c5.4-9.4 8.6-20.3 8.6-32v-8c0-60.7-27.1-115.2-69.8-151.8c2.4-.1 4.7-.2 7.1-.2h61.4C567.8 320 640 392.2 640 481.3c0 17-13.8 30.7-30.7 30.7zM432 256c-31 0-59-12.6-79.3-32.9C372.4 196.5 384 163.6 384 128c0-26.8-6.6-52.1-18.3-74.3C384.3 40.1 407.2 32 432 32c61.9 0 112 50.1 112 112s-50.1 112-112 112z"/></svg>
+							<!-- MIT Icon https://www.svgrepo.com/svg/347809/people -->
+							<svg class="verticle-align--middle" viewBox="0 0 24 24">
+								<g stroke="var(--primary-fill-color)" stroke-width="0.6">
+									<path fill-rule="evenodd" d="M3.5 8a5.5 5.5 0 118.596 4.547 9.005 9.005 0 015.9 8.18.75.75 0 01-1.5.045 7.5 7.5 0 00-14.993 0 .75.75 0 01-1.499-.044 9.005 9.005 0 015.9-8.181A5.494 5.494 0 013.5 8zM9 4a4 4 0 100 8 4 4 0 000-8z"/>
+									<path d="M17.29 8c-.148 0-.292.01-.434.03a.75.75 0 11-.212-1.484 4.53 4.53 0 013.38 8.097 6.69 6.69 0 013.956 6.107.75.75 0 01-1.5 0 5.193 5.193 0 00-3.696-4.972l-.534-.16v-1.676l.41-.209A3.03 3.03 0 0017.29 8z"/>
+								</g>
+							</svg>
 							Online Players
 						</h4>
 						<button type="button" class="close" data-dismiss="modal">&times;</button>

--- a/src/js/chat.js
+++ b/src/js/chat.js
@@ -11,7 +11,7 @@ var chathandler={
 		const header=$("<div class='roomheader flex flex-space-between flex-align-center'/>").append(name).click(selectThis);
 		const roombody=$("<div class='roombody'/>");
 		if(id!="global-"){
-			const closebutton=$("<button class='chatclose'><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'><path d='M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z'/></svg></button>").click(closeThis);
+			const closebutton=$(`<button class='chatclose'>${closeIcon}</button>`).click(closeThis);
 			header.append(closebutton);
 		}
 		this.rooms[id]=[header,roombody,""];

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -135,6 +135,20 @@ const gamePresets = {
 		required_fields: ["opname"],
 	}
 };
+// MIT Icon https://www.svgrepo.com/svg/343672/fullscreen-exit
+const fullscreenIcon = `<svg class="navicon-20" viewBox="0 0 32 32" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M4 12 L12 12 12 4 M20 4 L20 12 28 12 M4 20 L12 20 12 28 M28 20 L20 20 20 28" fill="none"/></svg>`;
+// PD Icon https://www.svgrepo.com/svg/502614/delete
+const deleteIcon = `<svg viewBox="0 0 24 24" fill="none"><g fill="none" stroke="var(--primary-stroke-color)"><path d="M10 11V17" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 11V17" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M4 7H20" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M6 7H12H18V18C18 19.6569 16.6569 21 15 21H9C7.34315 21 6 19.6569 6 18V7Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M9 5C9 3.89543 9.89543 3 11 3H13C14.1046 3 15 3.89543 15 5V7H9V5Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></g></svg>`;
+// Lucide Icons (ISC) - swords - https://lucide.dev/icons/swords
+const challengeIcon = `<svg class="navicon-20" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><g fill="none" stroke="var(--primary-stroke-color)" stroke-width="2" transform="translate(12 12) scale(1.3) translate(-12 -12)"><path d="m13 19 6-6" /><path d="M14.5 17.5 3.586 6.586A2 2 0 013 5.172V3h2.172a2 2 0 011.414.586L17.5 14.5" /><path d="m14.828 6.172 2.586-2.586A2 2 0 0118.828 3H21v2.172a2 2 0 01-.586 1.414l-2.586 2.586" /><path d="m16 16 4 4" /><path d="m19 21 2-2" /><path d="m5 14 4 4" /><path d="m5 21-2-2" /><path d="M7.5 16.5 4 20" /></g></svg>`;
+// Message Square Plus Icon - Dazzle UI | https://www.svgrepo.com/svg/533278/message-square-plus
+const messageIcon =	`<svg viewBox="0 0 24 24" fill="none"><path d="M9 11H15M12 8V14M21 20L17.6757 18.3378C17.4237 18.2118 17.2977 18.1488 17.1656 18.1044C17.0484 18.065 16.9277 18.0365 16.8052 18.0193C16.6672 18 16.5263 18 16.2446 18H6.2C5.07989 18 4.51984 18 4.09202 17.782C3.71569 17.5903 3.40973 17.2843 3.21799 16.908C3 16.4802 3 15.9201 3 14.8V7.2C3 6.07989 3 5.51984 3.21799 5.09202C3.40973 4.71569 3.71569 4.40973 4.09202 4.21799C4.51984 4 5.0799 4 6.2 4H17.8C18.9201 4 19.4802 4 19.908 4.21799C20.2843 4.40973 20.5903 4.71569 20.782 5.09202C21 5.51984 21 6.0799 21 7.2V20Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" stroke="var(--primary-stroke-color)"/></svg>`;
+// PD Icon https://www.svgrepo.com/svg/535754/dots-vertical
+const ellipsisIcon = `<svg viewBox="0 0 16 16" fill="none"><path d="M8 12C9.10457 12 10 12.8954 10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12Z"/><path d="M8 6C9.10457 6 10 6.89543 10 8C10 9.10457 9.10457 10 8 10C6.89543 10 6 9.10457 6 8C6 6.89543 6.89543 6 8 6Z"/><path d="M10 2C10 0.89543 9.10457 -4.82823e-08 8 0C6.89543 4.82823e-08 6 0.895431 6 2C6 3.10457 6.89543 4 8 4C9.10457 4 10 3.10457 10 2Z"/></svg>`;
+//  MLP Icon https://www.svgrepo.com/svg/503004/close
+const closeIcon = `<svg class="navicon-20" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.207 6.207a1 1 0 0 0-1.414-1.414L12 10.586 6.207 4.793a1 1 0 0 0-1.414 1.414L10.586 12l-5.793 5.793a1 1 0 1 0 1.414 1.414L12 13.414l5.793 5.793a1 1 0 0 0 1.414-1.414L13.414 12l5.793-5.793z"/></svg>`
+// PD icon https://www.svgrepo.com/svg/505373/eye-open 
+const watchIcon = `<svg viewBox="0 0 24 24" fill="none"><g fill="none" stroke="var(--primary-stroke-color)"><path d="M12 5C5.63636 5 2 12 2 12C2 12 5.63636 19 12 19C18.3636 19 22 12 22 12C22 12 18.3636 5 12 5Z" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/><path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></g></svg>`;
 
 // Evaluated at load rather than inside init(): prefers2DBoard() reads ismobile
 // from $(document).ready, which runs before init() does. Leaving it unset until
@@ -221,8 +235,7 @@ function init() {
 		let li = document.createElement("li");
 		fsbutton.title = "Toggle Fullscreen";
 		fsbutton.className = "navitem";
-		fsbutton.innerHTML =
-			'<svg viewBox="0 0 14 14" class="navicon"><g fill-rule="evenodd" id="Page-1" stroke="none" stroke-width="1"><g id="Core" transform="translate(-257.000000, -257.000000)"><g id="fullscreen-exit" transform="translate(257.000000, 257.000000)"><path d="M0,11 L3,11 L3,14 L5,14 L5,9 L0,9 L0,11 L0,11 Z M3,3 L0,3 L0,5 L5,5 L5,0 L3,0 L3,3 L3,3 Z M9,14 L11,14 L11,11 L14,11 L14,9 L9,9 L9,14 L9,14 Z M11,3 L11,0 L9,0 L9,5 L14,5 L14,3 L11,3 L11,3 Z" id="Shape"/></g></g></g></svg>';
+		fsbutton.innerHTML = fullscreenIcon;
 		fsbutton.onclick = togglefs;
 		li.appendChild(fsbutton);
 		document.getElementById("main-nav").appendChild(li);

--- a/src/js/server.js
+++ b/src/js/server.js
@@ -1167,7 +1167,7 @@ var server = {
 		players.innerHTML = p1Element + " vs " + p2Element;
 		const actionButton = document.createElement("button");
 		actionButton.className = "btn btn-transparent";
-		actionButton.innerHTML = `<svg viewBox="0 0 576 512"><path d="M160 256C160 185.3 217.3 128 288 128C358.7 128 416 185.3 416 256C416 326.7 358.7 384 288 384C217.3 384 160 326.7 160 256zM288 336C332.2 336 368 300.2 368 256C368 211.8 332.2 176 288 176C287.3 176 286.7 176 285.1 176C287.3 181.1 288 186.5 288 192C288 227.3 259.3 256 224 256C218.5 256 213.1 255.3 208 253.1C208 254.7 208 255.3 208 255.1C208 300.2 243.8 336 288 336L288 336zM95.42 112.6C142.5 68.84 207.2 32 288 32C368.8 32 433.5 68.84 480.6 112.6C527.4 156 558.7 207.1 573.5 243.7C576.8 251.6 576.8 260.4 573.5 268.3C558.7 304 527.4 355.1 480.6 399.4C433.5 443.2 368.8 480 288 480C207.2 480 142.5 443.2 95.42 399.4C48.62 355.1 17.34 304 2.461 268.3C-.8205 260.4-.8205 251.6 2.461 243.7C17.34 207.1 48.62 156 95.42 112.6V112.6zM288 80C222.8 80 169.2 109.6 128.1 147.7C89.6 183.5 63.02 225.1 49.44 256C63.02 286 89.6 328.5 128.1 364.3C169.2 402.4 222.8 432 288 432C353.2 432 406.8 402.4 447.9 364.3C486.4 328.5 512.1 286 526.6 256C512.1 225.1 486.4 183.5 447.9 147.7C406.8 109.6 353.2 80 288 80V80z"/></svg>`;
+		actionButton.innerHTML = watchIcon;
 		const row = $('<tr/>').attr("id", "game-" + game.id).addClass('game'+game.id).appendTo($('#gamelist'));
 		$('<td/>').append(actionButton).attr("data-toggle", "tooltip").attr("title", "Watch game").click(game,function(ev){server.observegame(ev.data);}).appendTo(row);
 		$('<td/>').append(players).click(game,function(ev){server.observegame(ev.data);}).appendTo(row);
@@ -1208,8 +1208,7 @@ var server = {
 
 		const dropdownButton = document.createElement("button");
 		dropdownButton.className = "btn btn-transparent dropdown-toggle";
-		// vertical elipse svg icon
-		dropdownButton.innerHTML = `<svg viewBox="0 0 24 24"><path d="M12,8A2,2 0 1,1 10,6A2,2 0 0,1 12,8M12,14A2,2 0 1,1 10,12A2,2 0 0,1 12,14M12,20A2,2 0 1,1 10,18A2,2 0 0,1 12,20Z"/></svg>`;
+		dropdownButton.innerHTML = ellipsisIcon;
 		dropdownButton.setAttribute("data-toggle", "dropdown");
 		dropdownButton.setAttribute("aria-haspopup", "true");
 		dropdownButton.setAttribute("aria-expanded", "false");
@@ -1303,6 +1302,7 @@ var server = {
 					yourColor = colourleft;
 				}
 			}
+			// custom player color icon
 			const imgstring='<svg class="colourcircle" viewBox="0 0 16 16"><circle cx="8" cy="8" r="6" stroke-width="2" fill="'+colourleft+'"></circle><clipPath id="g-clip"><rect height="16" width="8" x="8" y="0"></rect></clipPath><circle cx="8" cy="8" r="6" stroke-width="2" fill="'+colourright+'" clip-path="url(#g-clip)"></circle></svg>';
 			const sizespan = "<span class='badge'>"+seek.size+"</span>";
 			const row = $('<tr/>')
@@ -1378,8 +1378,6 @@ var server = {
 			const challengePlayerButton = document.createElement("button");
 			challengePlayerButton.className = "btn btn-transparent seek-button";
 			challengePlayerButton.innerHTML = `<span class='playername'>${seek.player}</span>`;
-			const deleteIcon = '<svg viewBox="0 0 24 24"><path d="M17,4V5H15V4H9V5H7V4A2,2,0,0,1,9,2h6A2,2,0,0,1,17,4Z"/><path d="M20,6H4A1,1,0,0,0,4,8H5V20a2,2,0,0,0,2,2H17a2,2,0,0,0,2-2V8h1a1,1,0,0,0,0-2ZM11,17a1,1,0,0,1-2,0V11a1,1,0,0,1,2,0Zm4,0a1,1,0,0,1-2,0V11a1,1,0,0,1,2,0Z"/></svg>';
-			const challengeIcon = `<svg viewBox="0 0 32 32"><path d="M28.414,24l-3-3l2.293-2.293l-1.414-1.414l-2.236,2.236l-3.588-4.186L25,11.46V6h-5.46L16,10.13  L12.46,6H7v5.46l4.531,3.884l-3.588,4.186l-2.236-2.236l-1.414,1.414L6.586,21l-3,3L7,27.414l3-3l2.293,2.293l1.414-1.414 l-2.237-2.237L16,19.174l4.53,3.882l-2.237,2.237l1.414,1.414L22,24.414l3,3L28.414,24z M6.414,24L8,22.414L8.586,23L7,24.586 L6.414,24z M9,10.54V8h2.54l3.143,3.667l-1.85,2.159L9,10.54z M20.46,8H23v2.54L10.053,21.638l-0.69-0.69L20.46,8z M18.95,16.645 l3.688,4.302l-0.69,0.69l-4.411-3.781L18.95,16.645z M25,24.586L23.414,23L24,22.414L25.586,24L25,24.586z"/></svg>`;
 			const actionButton = document.createElement("button");
 			actionButton.className = "btn btn-transparent";
 			actionButton.innerHTML = mySeek ? deleteIcon : challengeIcon;
@@ -1438,7 +1436,7 @@ var server = {
 			const dropdownButton = document.createElement("button");
 			dropdownButton.className = "btn btn-transparent dropdown-toggle";
 			// vertical elipse svg icon
-			dropdownButton.innerHTML = `<svg viewBox="0 0 24 24"><path d="M12,8A2,2 0 1,1 10,6A2,2 0 0,1 12,8M12,14A2,2 0 1,1 10,12A2,2 0 0,1 12,14M12,20A2,2 0 1,1 10,18A2,2 0 0,1 12,20Z"/></svg>`;
+			dropdownButton.innerHTML = ellipsisIcon;
 			dropdownButton.setAttribute("data-toggle", "dropdown");
 			dropdownButton.setAttribute("aria-haspopup", "true");
 			dropdownButton.setAttribute("aria-expanded", "false");
@@ -1518,7 +1516,7 @@ var server = {
 			challengeButton.className = "btn btn-transparent";
 			challengeButton.setAttribute("data-toggle", "tooltip");
 			challengeButton.setAttribute("title", "Challenge " + player);
-			challengeButton.innerHTML = `<svg viewBox="0 0 32 32"><path d="M28.414,24l-3-3l2.293-2.293l-1.414-1.414l-2.236,2.236l-3.588-4.186L25,11.46V6h-5.46L16,10.13  L12.46,6H7v5.46l4.531,3.884l-3.588,4.186l-2.236-2.236l-1.414,1.414L6.586,21l-3,3L7,27.414l3-3l2.293,2.293l1.414-1.414  l-2.237-2.237L16,19.174l4.53,3.882l-2.237,2.237l1.414,1.414L22,24.414l3,3L28.414,24z M6.414,24L8,22.414L8.586,23L7,24.586  L6.414,24z M9,10.54V8h2.54l3.143,3.667l-1.85,2.159L9,10.54z M20.46,8H23v2.54L10.053,21.638l-0.69-0.69L20.46,8z M18.95,16.645 l3.688,4.302l-0.69,0.69l-4.411-3.781L18.95,16.645z M25,24.586L23.414,23L24,22.414L25.586,24L25,24.586z"/></svg>`;
+			challengeButton.innerHTML = challengeIcon;
 			challengeButton.setAttribute("onclick", `server.challengePlayer('${player}')`);
 			row.innerHTML += `${challengeButton.outerHTML}`;
 			// create a message button
@@ -1526,7 +1524,7 @@ var server = {
 			messageButton.className = "btn btn-transparent";
 			messageButton.setAttribute("data-toggle", "tooltip");
 			messageButton.setAttribute("title", "Message " + player);
-			messageButton.innerHTML = `<svg viewBox="0 0 24 24"><path d="M20,2A2,2 0 0,1 22,4V16A2,2 0 0,1 20,18H6L2,22V4C2,2.89 2.9,2 4,2H20M11,6V9H8V11H11V14H13V11H16V9H13V6H11Z"></path></svg>`;
+			messageButton.innerHTML = messageIcon;
 			messageButton.setAttribute("onclick", `server.messagePlayer('${player}')`);
 			row.innerHTML += `${messageButton.outerHTML}`;
 			row.innerHTML += `</td>`;

--- a/src/js/style_selector.js
+++ b/src/js/style_selector.js
@@ -168,7 +168,7 @@ function makePieceElement(pieceData, file, color){
 	if(pieceData.can_delete){
 		const deleteButton = document.createElement("button");
 		deleteButton.classList.add('btn', 'btn-transparent');
-		deleteButton.innerHTML = '<svg viewBox="0 0 24 24"><path d="M17,4V5H15V4H9V5H7V4A2,2,0,0,1,9,2h6A2,2,0,0,1,17,4Z"/><path d="M20,6H4A1,1,0,0,0,4,8H5V20a2,2,0,0,0,2,2H17a2,2,0,0,0,2-2V8h1a1,1,0,0,0,0-2ZM11,17a1,1,0,0,1-2,0V11a1,1,0,0,1,2,0Zm4,0a1,1,0,0,1-2,0V11a1,1,0,0,1,2,0Z"/></svg>';
+		deleteButton.innerHTML = deleteIcon;
 		deleteButton.setAttribute("onclick", `deleteCustomPiece("${pieceData.id}")`);
 		li.appendChild(deleteButton);
 	}


### PR DESCRIPTION
refactor: update icons across playtak to be uniform across the site
chore: add license and icon links

makes all the icons more uniformed across the play tak site while adding license and urls for where the Icons came from.

Adds required attribution for the 2 icons that need it.

<img width="2614" height="1430" alt="Screenshot 2026-09-06 at 12 06 49 AM" src="https://github.com/user-attachments/assets/de774d53-5bda-4128-a2f8-1ce7d38dc8c8" />
